### PR TITLE
Remove usage of get_distribution function

### DIFF
--- a/bot/helper/ext_utils/status_utils.py
+++ b/bot/helper/ext_utils/status_utils.py
@@ -6,6 +6,7 @@ from subprocess import run as srun
 from mega import MegaApi
 from pkg_resources import DistributionNotFound, get_distribution
 from psutil import cpu_percent, disk_usage, virtual_memory
+from pyrogram import __version__ as pyrogramversionstr
 
 from bot import (
     DOWNLOAD_DIR,
@@ -76,14 +77,8 @@ def get_all_versions():
         result = srun(["rclone", "version"], capture_output=True, text=True)
         vr = result.stdout.split("\n")[0].split(" ")[1]
     except FileNotFoundError:
-        vr = ""
-    try:
-        vpy = get_distribution("pyrogram").version
-    except DistributionNotFound:
-        try:
-            vpy = get_distribution("pyrofork").version
-        except DistributionNotFound:
-            vpy = "2.xx.xx"
+        vr = ""    
+    vpy = pyrogramversionstr
     bot_cache["eng_versions"] = {
         "p7zip": vp,
         "ffmpeg": vf,


### PR DESCRIPTION
This pull request proposes removing the usage of `get_distribution` function, since the Official **Pyrogram** is kind of abandoned, and there are countably infinite number of Pyrogram forks, which could be changed by just changing the `requirements.txt` file without changing any other places in this source code.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request removes the usage of the `get_distribution` function for determining the Pyrogram version in `status_utils.py`. This change allows for easier switching between different Pyrogram forks by only modifying the `requirements.txt` file.

* **Enhancements**:
    - Removed the usage of `get_distribution` function to determine the Pyrogram version, simplifying the version retrieval process.

<!-- Generated by sourcery-ai[bot]: end summary -->