### PR TITLE
minor fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ pymongo
 pyrofork==2.2.11
 python-dotenv
 python-magic
+pytz
 qbittorrent-api
 requests
 speedtest-cli
@@ -42,4 +43,4 @@ tgcrypto
 uv
 uvloop
 xattr
-yt-dlp
+yt-dlp[default]

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,4 +43,4 @@ tgcrypto
 uv
 uvloop
 xattr
-yt-dlp[default]
+yt-dlp[default,curl-cffi]


### PR DESCRIPTION
some requirements is outdated and need to specify which to install

chose default installation for ytdlp
add pytz on requirements.txt

issue:
ModuleNotFoundError: No module named 'pytz'

## Summary by Sourcery

Update requirements.txt to fix a missing module error by adding pytz and specify default installation for yt-dlp.

Bug Fixes:
- Add pytz to requirements.txt to fix ModuleNotFoundError.

Enhancements:
- Specify default installation for yt-dlp in requirements.txt.