### PR TITLE
Typo

### DIFF
--- a/bot/helper/telegram_helper/bot_commands.py
+++ b/bot/helper/telegram_helper/bot_commands.py
@@ -10,7 +10,7 @@ class BotCommands:
     NzbMirrorCommand = [f"nzbmirror{Config.CMD_SUFFIX}", f"nm{Config.CMD_SUFFIX}"]
     LeechCommand = [f"leech{Config.CMD_SUFFIX}", f"l{Config.CMD_SUFFIX}"]
     QbLeechCommand = [f"qbleech{Config.CMD_SUFFIX}", f"ql{Config.CMD_SUFFIX}"]
-    JdLeechCommand = [f"jdLeech{Config.CMD_SUFFIX}", f"jl{Config.CMD_SUFFIX}"]
+    JdLeechCommand = [f"jdleech{Config.CMD_SUFFIX}", f"jl{Config.CMD_SUFFIX}"]
     YtdlLeechCommand = [f"ytdlleech{Config.CMD_SUFFIX}", f"yl{Config.CMD_SUFFIX}"]
     NzbLeechCommand = [f"nzbleech{Config.CMD_SUFFIX}", f"nl{Config.CMD_SUFFIX}"]
     CloneCommand = [f"clone{Config.CMD_SUFFIX}", f"cl{Config.CMD_SUFFIX}"]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct the `jdLeech` command to `jdleech`