### PR TITLE
feat: add swisstransfer direct link generator.

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -11,7 +11,7 @@ from time import sleep
 from urllib.parse import parse_qs, urlparse
 from urllib3.util.retry import Retry
 from uuid import uuid4
-from base64 import b64decode
+from base64 import b64decode, b64encode
 
 from ....core.config_manager import Config
 from ...ext_utils.exceptions import DirectDownloadLinkException
@@ -77,6 +77,8 @@ def direct_link_generator(link):
         return mp4upload(link)
     elif "berkasdrive.com" in domain:
         return berkasdrive(link)
+    elif "swisstransfer.com" in domain:
+        return swisstransfer(link)
     elif any(x in domain for x in ["akmfiles.com", "akmfls.xyz"]):
         return akmfiles(link)
     elif any(
@@ -1743,3 +1745,101 @@ def berkasdrive(url):
         return b64decode(link).decode("utf-8")
     else:
         raise DirectDownloadLinkException("ERROR: File Not Found!")
+
+def swisstransfer(link):
+    matched_link = match(
+        r"https://www\.swisstransfer\.com/d/([\w-]+)(?:\:\:(\w+))?", link
+    )
+    if not matched_link:
+        raise DirectDownloadLinkException(
+            f"ERROR: Invalid SwissTransfer link format {link}"
+        )
+
+    transfer_id, password = matched_link.groups()
+    password = password or ""
+
+    def encode_password(password):
+        return (
+            b64encode(password.encode("utf-8")).decode("utf-8") if password else ""
+        )
+
+    def getfile(transfer_id, password):
+        url = f"https://www.swisstransfer.com/api/links/{transfer_id}"
+        headers = {
+            "User-Agent": "Mozilla/5.0",
+            "Authorization": encode_password(password) if password else "",
+            "Content-Type": "application/json" if not password else "",
+        }
+        response = get(url, headers=headers)
+
+        if response.status_code == 200:
+            try:
+                return response.json(), headers
+            except ValueError:
+                raise DirectDownloadLinkException(
+                    f"ERROR: Error parsing JSON response {response.text}"
+                )
+        raise DirectDownloadLinkException(
+            f"ERROR: Error fetching file details {response.status_code}, {response.text}"
+        )
+
+    def gettoken(password, containerUUID, fileUUID):
+        url = "https://www.swisstransfer.com/api/generateDownloadToken"
+        headers = {
+            "User-Agent": "Mozilla/5.0",
+            "Content-Type": "application/json",
+        }
+        body = {
+            "password": password,
+            "containerUUID": containerUUID,
+            "fileUUID": fileUUID,
+        }
+
+        response = post(url, headers=headers, json=body)
+
+        if response.status_code == 200:
+            return response.text.strip().replace('"', "")
+        raise DirectDownloadLinkException(
+            f"ERROR: Error generating download token {response.status_code}, {response.text}"
+        )
+
+    data, headers = getfile(transfer_id, password)
+    if not data:
+        return None
+
+    try:
+        container_uuid = data["data"]["containerUUID"]
+        download_host = data["data"]["downloadHost"]
+        files = data["data"]["container"]["files"]
+        folder_name = data["data"]["container"]["message"] or "unknown"
+    except (KeyError, IndexError, TypeError) as e:
+        raise DirectDownloadLinkException(f"ERROR: Error parsing file details {e}")
+
+    total_size = sum(file["fileSizeInBytes"] for file in files)
+
+    if len(files) == 1:
+        file = files[0]
+        file_uuid = file["UUID"]
+        token = gettoken(password, container_uuid, file_uuid)
+        download_url = f"https://{download_host}/api/download/{transfer_id}/{file_uuid}?token={token}"
+        return download_url, "User-Agent:Mozilla/5.0"
+
+    contents = []
+    for file in files:
+        file_uuid = file["UUID"]
+        file_name = file["fileName"]
+        file_size = file["fileSizeInBytes"]
+
+        token = gettoken(password, container_uuid, file_uuid)
+        if not token:
+            continue
+
+        download_url = f"https://{download_host}/api/download/{transfer_id}/{file_uuid}?token={token}"
+        contents.append({"filename": file_name, "path": "", "url": download_url})
+
+    return {
+        "contents": contents,
+        "title": folder_name,
+        "total_size": total_size,
+        "header": "User-Agent:Mozilla/5.0",
+    }


### PR DESCRIPTION
- for password protected link link::password
- example: https://www.swisstransfer.com/d/05bd80dd-7ac0-420e-8a10-008b1c22c7f1::reaper

## Summary by Sourcery

New Features:
- Added support for generating direct download links from SwissTransfer, including password-protected links.