### PR TITLE
feat: Added Instagram direct download without using yt-dlp

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -23,6 +23,7 @@ class Config:
     FORCE_SUB_IDS = ""
     GDRIVE_ID = ""
     GD_DESP = "Uploaded with WZ Bot"
+    INSTADL_API = ""
     INCOMPLETE_TASK_NOTIFIER = False
     INDEX_URL = ""
     IS_TEAM_DRIVE = False

--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -81,6 +81,8 @@ def direct_link_generator(link):
         return berkasdrive(link)
     elif "swisstransfer.com" in domain:
         return swisstransfer(link)
+    elif "instagram.com" in domain:
+        return instagram(link)
     elif any(x in domain for x in ["akmfiles.com", "akmfls.xyz"]):
         return akmfiles(link)
     elif any(
@@ -1887,3 +1889,39 @@ def swisstransfer(link):
         "total_size": total_size,
         "header": "User-Agent:Mozilla/5.0",
     }
+def instagram(link: str) -> str:
+    """
+    Fetches the direct video download URL from an Instagram post.
+
+    Args:
+        link (str): The Instagram post URL.
+
+    Returns:
+        str: The direct video URL.
+
+    Raises:
+        DirectDownloadLinkException: If any error occurs during the process.
+    """
+    if not Config.INSTADL_API:
+        raise DirectDownloadLinkException(
+            f"ERROR: Instagram downloader API not added, Try ytdl commands"
+        )
+    full_url = f"{Config.INSTADL_API}/api/video?postUrl={link}"
+
+    try:
+        response = get(full_url)
+        response.raise_for_status()
+
+        data = response.json()
+
+        if (
+            data.get("status") == "success"
+            and "data" in data
+            and "videoUrl" in data["data"]
+        ):
+            return data["data"]["videoUrl"]
+
+        raise DirectDownloadLinkException("ERROR: Failed to retrieve video URL.")
+
+    except Exception as e:
+        raise DirectDownloadLinkException(f"ERROR: {e}")

--- a/config_sample.py
+++ b/config_sample.py
@@ -27,6 +27,9 @@ UPLOAD_PATHS = {}
 # Hyper Tg Downloader
 HELPER_TOKENS = ""
 
+#Ista video downloader api
+INSTADL_API = ""
+
 # Task Tools
 FORCE_SUB_IDS = ""
 MEDIA_STORE = True


### PR DESCRIPTION
This pull request introduces new functionality for downloading videos from Instagram by adding an Instagram downloader API configuration and implementing the necessary logic to support it. The most important changes include updates to the configuration files and the addition of a new method to handle Instagram links.

Configuration updates:

* [`bot/core/config_manager.py`](diffhunk://#diff-d6c201cee1b7728a39bc5e0a4fd154975264c5b5f4d3cb6179b2d648214525adR26): Added `INSTADL_API` configuration parameter to store the Instagram downloader API URL.
* [`config_sample.py`](diffhunk://#diff-554ea4296bad1e9974e3a316b3f4aeac4ee91b97e103665037184bda92ee6c52R30-R32): Added a sample `INSTADL_API` configuration parameter for users to set their Instagram downloader API URL.

Functionality updates:

* [`bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py`](diffhunk://#diff-343dfbbe892db1a3d9611849e180e3963e935392a17478c629f8e5c71c54a8f0R1892-R1927): Added a new method `instagram` to fetch direct video download URLs from Instagram posts using the configured API.
* [`bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py`](diffhunk://#diff-343dfbbe892db1a3d9611849e180e3963e935392a17478c629f8e5c71c54a8f0R84-R85): Updated the `direct_link_generator` function to handle Instagram links by calling the new `instagram` method.

## Summary by Sourcery

New Features:
- Adds support for downloading videos from Instagram directly using an external API.