### PR TITLE
feat: update Instagram function to use default API URL if INSTADL_API is not set

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -1902,22 +1902,18 @@ def instagram(link: str) -> str:
     Raises:
         DirectDownloadLinkException: If any error occurs during the process.
     """
-    if not Config.INSTADL_API:
-        raise DirectDownloadLinkException(
-            f"ERROR: Instagram downloader API not added, Try ytdl commands"
-        )
-    full_url = f"{Config.INSTADL_API}/api/video?postUrl={link}"
-
+    api_url = Config.INSTADL_API or 'https://instagramcdn.vercel.app'
+    full_url = f"{api_url}/api/video?postUrl={link}"
+    
     try:
         response = get(full_url)
         response.raise_for_status()
-
         data = response.json()
 
         if (
-            data.get("status") == "success"
-            and "data" in data
-            and "videoUrl" in data["data"]
+            data.get("status") == "success" and
+            "data" in data and
+            "videoUrl" in data["data"]
         ):
             return data["data"]["videoUrl"]
 


### PR DESCRIPTION
This pull request includes changes to the `instagram` function in the `bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py` file. The changes improve the handling of the Instagram downloader API by providing a default API URL and simplifying the code structure.

Improvements to API handling and code simplification:

* [`bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py`](diffhunk://#diff-343dfbbe892db1a3d9611849e180e3963e935392a17478c629f8e5c71c54a8f0L1905-R1916): Updated the `instagram` function to use a default API URL if `Config.INSTADL_API` is not set, ensuring the function can still operate without a specific API configuration. Simplified the conditional checks for the response data.

## Summary by Sourcery

Updates the Instagram function to use a default API URL if INSTADL_API is not set, ensuring the function can still operate without a specific API configuration. Simplifies the conditional checks for the response data.

Enhancements:
- Simplifies the conditional checks for the response data.
- Uses a default API URL if INSTADL_API is not set.