### PR TITLE
added : Lulacloud.com Direct Link Generator

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -35,6 +35,8 @@ def direct_link_generator(link):
         return buzzheavier(link)
     elif "devuploads" in domain:
         return devuploads(link)
+    elif "lulacloud.com" in domain:
+         return lulacloud(link)
     elif "fuckingfast.co" in domain:
         return fuckingfast_dl(link)
     elif "mediafire.com" in domain:
@@ -341,6 +343,20 @@ def devuploads(url):
     session.close()
     return direct_link[0]
 
+def lulacloud(url):
+    """
+    Generate a direct download link for www.lulacloud.com URLs.
+    @param url: URL from www.lulacloud.com
+    @return: Direct download link
+    """
+    session = Session()
+    try:
+        res = session.post(url, headers={'Referer': url}, allow_redirects=False)
+        return res.headers['location']
+    except Exception as e:
+        raise DirectDownloadLinkException(f"ERROR: {str(e)}") from e
+    finally:
+        session.close()
 
 def mediafire(url, session=None):
     if "/folder/" in url:


### PR DESCRIPTION
Actual Commit: anasty17/mirror-leech-telegram-bot@48df5ca
Credits: https://github.com/anasty17

## Summary by Sourcery

Add support for generating direct download links from Lulacloud.com

New Features:
- Implement a direct link generator function for Lulacloud.com file hosting service

Enhancements:
- Extend the existing direct link generator utility to support an additional file hosting domain