### PR TITLE
fix: crash when generating thumbnails for 4K videos.

### DIFF
--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -251,13 +251,13 @@ async def get_video_thumbnail(video_file, duration):
         "-i",
         video_file,
         "-vf",
-        "thumbnail",
+        "scale=640:-1",
         "-q:v",
-        "1",
-        "-frames:v",
+        "5",
+        "-vframes",
         "1",
         "-threads",
-        f"{max(1, cpu_no // 2)}",
+        "1",
         output,
     ]
     try:


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Modify the thumbnail generation process to prevent crashes, particularly with high-resolution videos, by scaling the output and limiting resource usage.