### PR TITLE
feat: add Torrent Disable option

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -16,6 +16,7 @@ class Config:
     DATABASE_URL = ""
     DEFAULT_UPLOAD = "rc"
     DELETE_LINKS = False
+    DISABLE_TORRENTS = False
     EQUAL_SPLITS = False
     EXCLUDED_EXTENSIONS = ""
     FFMPEG_CMDS = {}

--- a/bot/core/torrent_manager.py
+++ b/bot/core/torrent_manager.py
@@ -13,6 +13,7 @@ from tenacity import (
     wait_exponential,
 )
 
+from bot.core.config_manager import Config
 from .. import LOGGER, aria2_options
 
 
@@ -41,6 +42,10 @@ class TorrentManager:
 
     @classmethod
     async def initiate(cls):
+        if Config.DISABLE_TORRENTS:
+            LOGGER.info("Torrents are disabled in the configuration.")
+            return
+    
         cls.aria2, cls.qbittorrent = await gather(
             Aria2WebsocketClient.new("http://localhost:6800/jsonrpc"),
             create_client("http://localhost:8090/api/v2/"),

--- a/bot/helper/mirror_leech_utils/download_utils/aria2_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/aria2_download.py
@@ -14,6 +14,9 @@ from ...telegram_helper.message_utils import send_status_message, send_message
 
 
 async def add_aria2_download(listener, dpath, header, ratio, seed_time):
+    if Config.DISABLE_TORRENTS:
+        await listener.on_download_error("Torrents are disabled in the configuration.")
+        return
     a2c_opt = {"dir": dpath}
     if listener.name:
         a2c_opt["out"] = listener.name

--- a/bot/helper/mirror_leech_utils/download_utils/qbit_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/qbit_download.py
@@ -42,6 +42,9 @@ def _get_hash_file(fpath):
 
 
 async def add_qb_torrent(listener, path, ratio, seed_time):
+    if Config.DISABLE_TORRENTS:
+        await listener.on_download_error("Torrents are disabled in the configuration.")
+        return
     try:
         form = AddFormBuilder.with_client(TorrentManager.qbittorrent)
         if await aiopath.exists(listener.link):

--- a/config_sample.py
+++ b/config_sample.py
@@ -150,6 +150,9 @@ LEECH_CAPTION = ""
 LEECH_DUMP_CHAT = ""
 THUMBNAIL_LAYOUT = ""
 
+#Disable Torrent
+DISABLE_TORRENTS = False
+
 # qBittorrent/Aria2c
 TORRENT_TIMEOUT = 0
 BASE_URL = ""


### PR DESCRIPTION
## Summary by Sourcery

Add a configuration option to disable torrent downloads completely

New Features:
- Introduce DISABLE_TORRENTS configuration option to prevent torrent downloads

Chores:
- Update config_sample.py to include new DISABLE_TORRENTS setting
- Update Config class to support the new configuration option