### PR TITLE
feat: Add Custom Telegraph Author flags

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -25,6 +25,8 @@ class Config:
     FORCE_SUB_IDS = ""
     GDRIVE_ID = ""
     GD_DESP = "Uploaded with WZ Bot"
+    AUTHOR_NAME = "WZML-X"
+    AUTHOR_URL = "https://t.me/WZML_X"
     INSTADL_API = ""
     IMDB_TEMPLATE = ""
     INCOMPLETE_TASK_NOTIFIER = False

--- a/bot/helper/ext_utils/telegraph_helper.py
+++ b/bot/helper/ext_utils/telegraph_helper.py
@@ -4,6 +4,7 @@ from telegraph.aio import Telegraph
 from telegraph.exceptions import RetryAfterError
 
 from ... import LOGGER
+from ...core.config_manager import Config
 
 
 class TelegraphHelper:
@@ -73,12 +74,12 @@ class TelegraphHelper:
                     nxt_page += 1
             await self.edit_page(
                 path=path[prev_page],
-                title="Mirror-leech-bot Torrent Search",
+                title="WZML-X Torrent Search",
                 content=content,
             )
         return
 
 
-telegraph = TelegraphHelper("WZML-X", "https://github.com/SilentDemonSD/WZML-X")
+telegraph = TelegraphHelper(Config.AUTHOR_NAME, Config.AUTHOR_URL)
 
 print(__name__)

--- a/config_sample.py
+++ b/config_sample.py
@@ -37,6 +37,10 @@ MEGA_PASSWORD = ""
 # Disable Torrent
 DISABLE_TORRENTS = False
 
+# Telegraph
+AUTHOR_NAME = "WZML-X"
+AUTHOR_URL = "https://t.me/WZML_X"
+
 # Task Limits
 DIRECT_LIMIT = 0
 MEGA_LIMIT = 0


### PR DESCRIPTION
## Summary by Sourcery

Introduce configurable Telegraph author name and URL, updating relevant code and configuration samples to support custom author information.

New Features:
- Add configurable Telegraph author name and URL via config.

Enhancements:
- Update default Telegraph page title and author information to use config values.

Documentation:
- Add sample Telegraph author configuration to config_sample.py.