### PR TITLE
feat: Add DISABLE_BULK Option

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -18,6 +18,7 @@ class Config:
     DELETE_LINKS = False
     DISABLE_TORRENTS = False
     DISABLE_LEECH = False
+    DISABLE_BULK = False
     EQUAL_SPLITS = False
     EXCLUDED_EXTENSIONS = ""
     FFMPEG_CMDS = {}

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -560,6 +560,9 @@ class TaskConfig:
         ).new_event()
 
     async def init_bulk(self, input_list, bulk_start, bulk_end, obj):
+        if Config.DISABLE_BULK:
+            await send_message(self.message, "Bulk downloads are currently disabled.")
+            return
         try:
             self.bulk = await extract_bulk_links(self.message, bulk_start, bulk_end)
             if len(self.bulk) == 0:

--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -156,6 +156,8 @@ def arg_parser(items, arg_base):
         "-ut",
         "-bt",
     }
+    if Config.DISABLE_BULK and "-b" in items:
+        arg_base["-b"] = False
 
     while i < total:
         part = items[i]

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -130,6 +130,10 @@ class Mirror(TaskListener):
 
         arg_parser(input_list[1:], args)
 
+        if Config.DISABLE_BULK and args.get("-b", False):
+            await send_message(self.message, "Bulk downloads are currently disabled.")
+            return
+
         self.select = args["-s"]
         self.seed = args["-d"]
         self.name = args["-n"]

--- a/config_sample.py
+++ b/config_sample.py
@@ -37,6 +37,7 @@ MEGA_PASSWORD = ""
 # Disable Options
 DISABLE_TORRENTS = False
 DISABLE_LEECH = False
+DISABLE_BULK = False
 
 # Telegraph
 AUTHOR_NAME = "WZML-X"


### PR DESCRIPTION
## Summary by Sourcery

Add a DISABLE_BULK option to globally disable bulk downloads and update command handlers and the argument parser to respect this setting

New Features:
- Introduce a DISABLE_BULK configuration setting to disable bulk downloads

Enhancements:
- Guard bulk download commands in mirror_leech and common workflows when DISABLE_BULK is active
- Override the -b argument in the bot_utils argument parser when bulk downloads are disabled

Documentation:
- Add DISABLE_BULK to the sample configuration file