### PR TITLE
fix: exclude specific codecs from being identified as video

### DIFF
--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -142,7 +142,9 @@ async def get_document_type(path):
         is_video = False
         for stream in fields:
             if stream.get("codec_type") == "video":
-                is_video = True
+                codec_name = stream.get("codec_name", "").lower()
+                if codec_name not in {"mjpeg", "png", "bmp"}:
+                    is_video = True
             elif stream.get("codec_type") == "audio":
                 is_audio = True
     return is_video, is_audio, is_image


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Exclude 'mjpeg', 'png', and 'bmp' codecs from being classified as video streams