### PR TITLE
feat: Add MIRROR_LOG_ID Option

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -57,6 +57,7 @@ class Config:
     STORAGE_LIMIT = 0
     LEECH_DUMP_CHAT = ""
     LINKS_LOG_ID = ""
+    MIRROR_LOG_ID = ""
     CLEAN_LOG_MSG = False
     LEECH_PREFIX = ""
     LEECH_CAPTION = ""

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -429,8 +429,19 @@ class TaskListener(TaskConfig):
             else:
                 msg += f"\n┃\n┠ Path: <code>{rclone_path}</code>"
                 button = None
-            msg += f"\n┃\n┖ <b>Task By</b> → {self.tag}"
-            await send_message(self.message, msg, button)
+            msg += f"\n┃\n┖ <b>Task By</b> → {self.tag}\n\n"
+            group_msg = (
+                msg + "〶 <b><u>Action Performed :</u></b>\n"
+                "⋗ <i>Cloud link(s) have been sent to User PM</i>\n\n"
+            )
+
+            if self.bot_pm and self.is_super_chat:
+                await send_message(self.user_id, msg, button)
+
+            if hasattr(Config, "MIRROR_LOG_ID") and Config.MIRROR_LOG_ID:
+                await send_message(Config.MIRROR_LOG_ID, msg, button)
+
+            await send_message(self.message, group_msg, button)
         if self.seed:
             await clean_target(self.up_dir)
             async with queue_dict_lock:

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -323,6 +323,16 @@ async def edit_variable(_, message, pre_message, key):
                     "Invalid value! LINKS_LOG_ID must be a valid integer chat ID.",
                 )
                 return await update_buttons(pre_message, "var")
+    elif key == "MIRROR_LOG_ID":
+        if value.strip():
+            try:
+                value = int(value.strip())
+            except ValueError:
+                await send_message(
+                    message,
+                    "Invalid value! MIRROR_LOG_ID must be a valid integer chat ID.",
+                )
+                return await update_buttons(pre_message, "var")
     elif key == "AUTHORIZED_CHATS":
         aid = value.split()
         auth_chats.clear()

--- a/config_sample.py
+++ b/config_sample.py
@@ -164,6 +164,7 @@ THUMBNAIL_LAYOUT = ""
 # Log Channels
 LEECH_DUMP_CHAT = ""
 LINKS_LOG_ID = ""
+MIRROR_LOG_ID = ""
 
 # qBittorrent/Aria2c
 TORRENT_TIMEOUT = 0


### PR DESCRIPTION
## Summary by Sourcery

Add MIRROR_LOG_ID option to route mirror task logs to a dedicated chat and optionally send logs to user PM for super chats, including validation and sample config updates.

New Features:
- Introduce MIRROR_LOG_ID config option to send mirror task logs to a separate log chat.
- Send upload completion logs to user private message for super chats when bot_pm is enabled.

Enhancements:
- Validate MIRROR_LOG_ID as an integer chat ID in the settings module.

Documentation:
- Include MIRROR_LOG_ID in the sample configuration file.

Chores:
- Add MIRROR_LOG_ID attribute to the Config class in config_manager.