### PR TITLE
feat: Add Support for Youtube Uploading (beta version)

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -113,6 +113,10 @@ class Config:
     USE_SERVICE_ACCOUNTS = False
     WEB_PINCODE = True
     YT_DLP_OPTIONS = {}
+    YT_DESP = "Uploaded with WZML-X bot"
+    YT_TAGS = ["telegram", "bot", "youtube"]
+    YT_CATEGORY_ID = 22
+    YT_PRIVACY_STATUS = "unlisted"
 
     @classmethod
     def get(cls, key):

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -83,6 +83,7 @@ class TaskConfig:
         self.subsize = 0
         self.proceed_count = 0
         self.is_leech = False
+        self.is_yt = False
         self.is_qbit = False
         self.is_mega = False
         self.is_nzb = False

--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -155,6 +155,7 @@ def arg_parser(items, arg_base):
         "-med",
         "-ut",
         "-bt",
+        "-yt",
     }
     if Config.DISABLE_BULK and "-b" in items:
         arg_base["-b"] = False
@@ -188,6 +189,7 @@ def arg_parser(items, arg_base):
                     "-med",
                     "-ut",
                     "-bt",
+                    "-yt",
                 ]
             ):
                 arg_base[part] = True

--- a/bot/helper/ext_utils/status_utils.py
+++ b/bot/helper/ext_utils/status_utils.py
@@ -35,6 +35,7 @@ class MirrorStatus:
     STATUS_SAMVID = "SamVid"
     STATUS_CONVERT = "Convert"
     STATUS_FFMPEG = "FFmpeg"
+    STATUS_YT = "YouTube"
 
 
 class EngineStatus:
@@ -52,6 +53,7 @@ class EngineStatus:
         self.STATUS_SABNZBD = f"SABnzbd+ v{bot_cache['eng_versions']['SABnzbd+']}"
         self.STATUS_QUEUE = "QSystem v2"
         self.STATUS_JD = "JDownloader v2"
+        self.STATUS_YT = "Youtube-Api"
 
 
 STATUSES = {

--- a/bot/helper/mirror_leech_utils/gdrive_utils/helper.py
+++ b/bot/helper/mirror_leech_utils/gdrive_utils/helper.py
@@ -219,26 +219,6 @@ class GoogleDriveHelper:
             estr = estr.replace(char, f"\\{char}")
         return estr.strip()
 
-    """
-    def get_recursive_list(self, file, rootId):
-        rtnlist = []
-        if not rootId:
-            rootId = file.get('teamDriveId')
-        if rootId == "root":
-            rootId = self.service.files().get(
-                fileId='root', fields='id').execute().get('id')
-        x = file.get("name")
-        y = file.get("id")
-        while (y != rootId):
-            rtnlist.append(x)
-            file = self.service.files().get(fileId=file.get("parents")[0], supportsAllDrives=True,
-                                            fields='id, name, parents').execute()
-            x = file.get("name")
-            y = file.get("id")
-        rtnlist.reverse()
-        return rtnlist
-    """
-
     async def cancel_task(self):
         self.listener.is_cancelled = True
         if self.is_downloading:

--- a/bot/helper/mirror_leech_utils/status_utils/yt_status.py
+++ b/bot/helper/mirror_leech_utils/status_utils/yt_status.py
@@ -1,0 +1,58 @@
+from ....helper.ext_utils.status_utils import (
+    MirrorStatus,
+    EngineStatus,
+    get_readable_file_size,
+    get_readable_time,
+)
+
+
+class YtStatus:
+    def __init__(self, listener, obj, gid, status):
+        self.listener = listener
+        self._obj = obj
+        self._size = self.listener.size
+        self._gid = gid
+        self._status = status
+        self.engine = EngineStatus().STATUS_YT
+
+    def processed_bytes(self):
+        return get_readable_file_size(self._obj.processed_bytes)
+
+    def size(self):
+        return get_readable_file_size(self._size)
+
+    def status(self):
+        if self._status == "up":
+            return MirrorStatus.STATUS_UPLOAD
+        elif self._status == "dl":
+            return MirrorStatus.STATUS_DOWNLOAD
+        else:
+            return MirrorStatus.STATUS_YT
+
+    def name(self):
+        return self.listener.name
+
+    def gid(self) -> str:
+        return self._gid
+
+    def progress_raw(self):
+        try:
+            return self._obj.processed_bytes / self._size * 100
+        except ZeroDivisionError:
+            return 0
+
+    def progress(self):
+        return f"{round(self.progress_raw(), 2)}%"
+
+    def speed(self):
+        return f"{get_readable_file_size(self._obj.speed)}/s"
+
+    def eta(self):
+        try:
+            seconds = (self._size - self._obj.processed_bytes) / self._obj.speed
+            return get_readable_time(seconds)
+        except Exception:
+            return "-"
+
+    def task(self):
+        return self._obj

--- a/bot/helper/mirror_leech_utils/youtube_utils/youtube_helper.py
+++ b/bot/helper/mirror_leech_utils/youtube_utils/youtube_helper.py
@@ -1,0 +1,130 @@
+from logging import ERROR, getLogger
+from os import path as ospath
+from pickle import load as pload
+from urllib.parse import parse_qs, urlparse
+
+from google_auth_httplib2 import AuthorizedHttp
+from googleapiclient.discovery import build
+from googleapiclient.http import build_http
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+LOGGER = getLogger(__name__)
+getLogger("googleapiclient.discovery").setLevel(ERROR)
+
+
+class YouTubeHelper:
+    def __init__(self):
+        self._OAUTH_SCOPE = [
+            "https://www.googleapis.com/auth/youtube.upload",
+            "https://www.googleapis.com/auth/youtube",
+        ]
+        self.token_path = "token.pickle"
+        self.is_uploading = False
+        self.service = None
+        self.total_files = 0
+        self.file_processed_bytes = 0
+        self.proc_bytes = 0
+        self.total_time = 0
+        self.status = None
+        self.update_interval = 3
+        self.upload_progress = 0
+
+    @property
+    def speed(self):
+        try:
+            return self.proc_bytes / self.total_time
+        except Exception:
+            return 0
+
+    @property
+    def processed_bytes(self):
+        return self.proc_bytes
+
+    async def progress(self):
+        if self.status is not None:
+            if hasattr(self.status, "total_size") and hasattr(self.status, "progress"):
+                chunk_size = (
+                    self.status.total_size * self.status.progress()
+                    - self.file_processed_bytes
+                )
+                self.file_processed_bytes = (
+                    self.status.total_size * self.status.progress()
+                )
+                self.proc_bytes += chunk_size
+                self.total_time += self.update_interval
+            else:
+                # For YouTube uploads, we'll track progress differently
+                self.total_time += self.update_interval
+
+    def authorize(self, user_id=""):
+        credentials = None
+        token_path = self.token_path
+
+        if user_id:
+            token_path = f"tokens/{user_id}.pickle"
+
+        if ospath.exists(token_path):
+            LOGGER.info(f"Authorize YouTube with {token_path}")
+            with open(token_path, "rb") as f:
+                credentials = pload(f)
+        else:
+            LOGGER.error(f"YouTube token file {token_path} not found!")
+            raise FileNotFoundError(f"YouTube token file {token_path} not found!")
+
+        authorized_http = AuthorizedHttp(credentials, http=build_http())
+        authorized_http.http.disable_ssl_certificate_validation = True
+        return build("youtube", "v3", http=authorized_http, cache_discovery=False)
+
+    def get_video_id_from_url(self, url):
+        """Extract video ID from YouTube URL"""
+        if "youtube.com/watch?v=" in url:
+            parsed = urlparse(url)
+            return parse_qs(parsed.query)["v"][0]
+        if "youtu.be/" in url:
+            return url.split("youtu.be/")[1].split("?")[0]
+        return url  # Assume it's already a video ID
+
+    @retry(
+        wait=wait_exponential(multiplier=2, min=3, max=6),
+        stop=stop_after_attempt(3),
+        retry=retry_if_exception_type(Exception),
+    )
+    def get_video_info(self, video_id):
+        """Get video information"""
+        return (
+            self.service.videos()
+            .list(part="snippet,statistics,status", id=video_id)
+            .execute()
+        )
+
+    @retry(
+        wait=wait_exponential(multiplier=2, min=3, max=6),
+        stop=stop_after_attempt(3),
+        retry=retry_if_exception_type(Exception),
+    )
+    def get_channel_info(self):
+        """Get channel information"""
+        return (
+            self.service.channels().list(part="snippet,statistics", mine=True).execute()
+        )
+
+    def escapes(self, estr):
+        """Escape special characters in strings"""
+        chars = ["\\", "'", '"', r"\a", r"\b", r"\f", r"\n", r"\r", r"\t"]
+        for char in chars:
+            estr = estr.replace(char, f"\\{char}")
+        return estr.strip()
+
+    async def cancel_task(self):
+        """Cancel the current upload task"""
+        self.listener.is_cancelled = True
+        if self.is_uploading:
+            LOGGER.info(f"Cancelling YouTube Upload: {self.listener.name}")
+            await self.listener.on_upload_error(
+                "Your YouTube upload has been cancelled!"
+            )

--- a/bot/helper/mirror_leech_utils/youtube_utils/youtube_upload.py
+++ b/bot/helper/mirror_leech_utils/youtube_utils/youtube_upload.py
@@ -1,0 +1,198 @@
+import contextlib
+from logging import getLogger
+from os import path as ospath
+from os import remove
+
+from bot.core.config_manager import Config
+from googleapiclient.errors import HttpError
+from googleapiclient.http import MediaFileUpload
+from tenacity import (
+    RetryError,
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from bot.helper.ext_utils.bot_utils import SetInterval, async_to_sync
+from bot.helper.ext_utils.files_utils import get_mime_type
+from bot.helper.mirror_leech_utils.youtube_utils.youtube_helper import YouTubeHelper
+
+LOGGER = getLogger(__name__)
+
+
+class YouTubeUpload(YouTubeHelper):
+    def __init__(self, listener, path):
+        self.listener = listener
+        self._updater = None
+        self._path = path
+        self._is_errored = False
+        super().__init__()
+        self.is_uploading = True
+
+    def user_setting(self):
+        """Handle user-specific YouTube token settings"""
+        if self.listener.up_dest.startswith("yt:"):
+            self.token_path = f"tokens/{self.listener.user_id}.pickle"
+            self.listener.up_dest = self.listener.up_dest.replace("yt:", "", 1)
+        elif hasattr(self.listener, "user_id") and self.listener.user_id:
+            self.token_path = f"tokens/{self.listener.user_id}.pickle"
+
+    def upload(self):
+        """Main upload function"""
+        self.user_setting()
+        try:
+            self.service = self.authorize(
+                self.listener.user_id if hasattr(self.listener, "user_id") else ""
+            )
+        except Exception as e:
+            LOGGER.error(f"YouTube authorization failed: {e}")
+            async_to_sync(
+                self.listener.on_upload_error, f"YouTube authorization failed: {e!s}"
+            )
+            return
+
+        LOGGER.info(f"Uploading to YouTube: {self._path}")
+        self._updater = SetInterval(self.update_interval, self.progress)
+        video_url = None
+
+        try:
+            if ospath.isfile(self._path):
+                mime_type = get_mime_type(self._path)
+
+                # Check if file is a video
+                if not mime_type.startswith("video/"):
+                    raise ValueError(f"File is not a video. MIME type: {mime_type}")
+
+                video_url = self._upload_video(
+                    self._path, self.listener.name, mime_type
+                )
+
+                if self.listener.is_cancelled:
+                    return
+
+                if video_url is None:
+                    raise ValueError("Upload has been manually cancelled")
+
+                LOGGER.info(f"Uploaded To YouTube: {self._path}")
+            else:
+                raise ValueError("YouTube only supports single video file uploads")
+
+        except Exception as err:
+            if isinstance(err, RetryError):
+                LOGGER.info(f"Total Attempts: {err.last_attempt.attempt_number}")
+                err = err.last_attempt.exception()
+            err = str(err).replace(">", "").replace("<", "")
+            LOGGER.error(err)
+            async_to_sync(self.listener.on_upload_error, err)
+            self._is_errored = True
+        finally:
+            self._updater.cancel()
+
+        if self.listener.is_cancelled and not self._is_errored:
+            return
+
+        if self._is_errored:
+            return
+
+        async_to_sync(
+            self.listener.on_upload_complete,
+            video_url,
+            1,  # total_files
+            0,  # total_folders
+            "Video",  # mime_type
+        )
+        return
+
+    @retry(
+        wait=wait_exponential(multiplier=2, min=3, max=6),
+        stop=stop_after_attempt(3),
+        retry=retry_if_exception_type(Exception),
+    )
+    def _upload_video(self, file_path, file_name, mime_type):
+        """Upload video to YouTube"""
+
+        # Default video metadata
+        title = file_name
+        description = Config.YT_DESP
+        tags = Config.YT_TAGS
+        category_id = Config.YT_CATEGORY_ID
+        privacy_status = Config.YT_PRIVACY_STATUS
+
+        body = {
+            "snippet": {
+                "title": title,
+                "description": description,
+                "tags": tags,
+                "categoryId": category_id,
+            },
+            "status": {
+                "privacyStatus": privacy_status,
+                "selfDeclaredMadeForKids": False,
+            },
+        }
+
+        # Create media upload object
+        media_body = MediaFileUpload(
+            file_path,
+            mimetype=mime_type,
+            resumable=True,
+            chunksize=1024 * 1024 * 4,  # 4MB chunks
+        )
+
+        # Create the upload request
+        insert_request = self.service.videos().insert(
+            part=",".join(body.keys()), body=body, media_body=media_body
+        )
+
+        response = None
+        retries = 0
+
+        while response is None and not self.listener.is_cancelled:
+            try:
+                self.status, response = insert_request.next_chunk()
+                if self.status:
+                    self.upload_progress = int(self.status.progress() * 100)
+                    LOGGER.info(f"Upload progress: {self.upload_progress}%")
+
+            except HttpError as err:
+                if err.resp.status in [500, 502, 503, 504, 429] and retries < 5:
+                    retries += 1
+                    LOGGER.warning(
+                        f"HTTP error {err.resp.status}, retrying... ({retries}/5)"
+                    )
+                    continue
+                error_content = (
+                    err.content.decode("utf-8") if err.content else "Unknown error"
+                )
+                LOGGER.error(f"YouTube upload failed: {error_content}")
+                raise err
+            except Exception as e:
+                LOGGER.error(f"Unexpected error during upload: {e}")
+                raise e
+
+        if self.listener.is_cancelled:
+            return None
+
+        # Clean up the file after successful upload
+        with contextlib.suppress(Exception):
+            remove(file_path)
+
+        self.file_processed_bytes = 0
+        self.total_files += 1
+
+        if response:
+            video_id = response["id"]
+            video_url = f"https://www.youtube.com/watch?v={video_id}"
+            LOGGER.info(f"Video uploaded successfully: {video_url}")
+            return video_url
+        raise ValueError("Upload completed but no response received")
+
+    def get_upload_status(self):
+        return {
+            "progress": self.upload_progress,
+            "speed": self.speed,
+            "processed_bytes": self.processed_bytes,
+            "total_files": self.total_files,
+            "is_uploading": self.is_uploading,
+        }

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -110,6 +110,7 @@ class Mirror(TaskListener):
             "-hl": False,
             "-bt": False,
             "-ut": False,
+            "-yt": False,
             "-i": 0,
             "-sp": 0,
             "link": "",
@@ -178,6 +179,7 @@ class Mirror(TaskListener):
         self.folder_name = f"/{args["-m"]}".rstrip("/") if len(args["-m"]) > 0 else ""
         self.bot_trans = args["-bt"]
         self.user_trans = args["-ut"]
+        self.is_yt = args["-yt"]
 
         headers = args["-h"]
         is_bulk = args["-b"]

--- a/config_sample.py
+++ b/config_sample.py
@@ -108,6 +108,12 @@ IS_TEAM_DRIVE = False
 STOP_DUPLICATE = False
 INDEX_URL = ""
 
+# YT Tools
+YT_DESP = "Uploaded to YouTube by WZML-X bot"
+YT_TAGS = ["telegram", "bot", "youtube"]  # or as a comma-separated string
+YT_CATEGORY_ID = 22
+YT_PRIVACY_STATUS = "unlisted"
+
 # Rclone
 RCLONE_PATH = ""
 RCLONE_FLAGS = ""


### PR DESCRIPTION
## Summary by Sourcery

Add beta support for uploading downloaded videos directly to YouTube by introducing a new `-yt` option, configuration settings, upload flow, and status tracking.

New Features:
- Add `-yt` argument to trigger YouTube uploads in mirror/leech commands
- Introduce YouTube-specific configuration parameters (description, tags, category, privacy) in config files
- Implement YouTubeUpload and YouTubeHelper classes for authenticated video uploads with retry and progress updates
- Integrate YouTube upload flow into the task listener with YtStatus for status reporting

Enhancements:
- Remove deprecated recursive GDrive listing helper
- Add YtStatus class to unify YouTube upload status with existing status utilities