### PR TITLE
fix: minor issue regarding yt upload

### DIFF
--- a/bot/helper/mirror_leech_utils/youtube_utils/youtube_upload.py
+++ b/bot/helper/mirror_leech_utils/youtube_utils/youtube_upload.py
@@ -126,7 +126,8 @@ class YouTubeUpload(YouTubeHelper):
                     )
 
             elif ospath.isfile(self.path):
-                video_url = self._upload_video(self.path, self.name, get_mime_type(self.path))
+                mime_type = get_mime_type(self.path) or "Video"
+                video_url = self._upload_video(self.path, self.name, mime_type)
 
                 if self.listener.is_cancelled:
                     return
@@ -193,7 +194,7 @@ class YouTubeUpload(YouTubeHelper):
                 video_url,
                 1,
                 0,
-                get_mime_type(self.path) or "Video",
+                mime_type,
             )
 
         return


### PR DESCRIPTION
## Summary by Sourcery

Unify mime type handling for video uploads by storing the detected mime type (or defaulting to "Video") in a variable and reusing it across upload calls.

Bug Fixes:
- Ensure consistent default mime type fallback by capturing get_mime_type(path) or "Video" in a variable
- Replace duplicate inline mime type retrieval with the stored variable for subsequent upload operations