### PR TITLE
feat: Add metadata editing capability

### DIFF
--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -397,6 +397,20 @@ class FFMpeg:
                             self._progress_raw = (
                                 self._processed_time * 100
                             ) / self._total_time
+                            if (
+                                hasattr(self._listener, "subsize")
+                                and self._listener.subsize
+                                and self._progress_raw > 0
+                            ):
+                                self._processed_bytes = int(
+                                    self._listener.subsize * (self._progress_raw / 100)
+                                )
+                            if (time() - self._start_time) > 0:
+                                self._speed_raw = self._processed_bytes / (
+                                    time() - self._start_time
+                                )
+                            else:
+                                self._speed_raw = 0
                             self._eta_raw = (
                                 self._total_time - self._processed_time
                             ) / self._time_rate

--- a/bot/helper/ext_utils/status_utils.py
+++ b/bot/helper/ext_utils/status_utils.py
@@ -36,6 +36,7 @@ class MirrorStatus:
     STATUS_CONVERT = "Convert"
     STATUS_FFMPEG = "FFmpeg"
     STATUS_YT = "YouTube"
+    STATUS_METADATA = "Metadata"
 
 
 class EngineStatus:
@@ -54,6 +55,7 @@ class EngineStatus:
         self.STATUS_QUEUE = "QSystem v2"
         self.STATUS_JD = "JDownloader v2"
         self.STATUS_YT = "Youtube-Api"
+        self.STATUS_METADATA = "Metadata"
 
 
 STATUSES = {

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -21,6 +21,7 @@ from ... import (
     same_directory_lock,
     DOWNLOAD_DIR,
 )
+from ...modules.metadata import apply_metadata_title
 from ..common import TaskConfig
 from ...core.tg_client import TgClient
 from ...core.config_manager import Config
@@ -232,6 +233,15 @@ class TaskListener(TaskConfig):
             self.size = await get_path_size(up_dir)
             self.clear()
 
+        if hasattr(self, "metadata_dict") and self.metadata_dict:
+            up_path = await apply_metadata_title(self, up_path, gid, self.metadata_dict)
+            if self.is_cancelled:
+                return
+
+            self.name = up_path.replace(f"{up_dir.rstrip('/')}/", "").split("/", 1)[0]
+            self.size = await get_path_size(up_path)
+            self.clear()
+
         if self.is_leech and self.is_file:
             fname = ospath.basename(up_path)
             self.file_details["filename"] = fname
@@ -380,7 +390,9 @@ class TaskListener(TaskConfig):
                 msg += f"\n┖ <b>Type</b> → Video"
                 if link:
                     buttons.url_button("🔗 View Video", link)
-                user_message = f"{self.tag}\nYour video has been uploaded to YouTube successfully!"
+                user_message = (
+                    f"{self.tag}\nYour video has been uploaded to YouTube successfully!"
+                )
 
             msg += f"\n\n<b>Task By: </b>{self.tag}"
 

--- a/bot/helper/mirror_leech_utils/status_utils/metadata_status.py
+++ b/bot/helper/mirror_leech_utils/status_utils/metadata_status.py
@@ -1,0 +1,65 @@
+from .... import LOGGER
+from ...ext_utils.status_utils import (
+    get_readable_file_size,
+    EngineStatus,
+    MirrorStatus,
+    get_readable_time,
+)
+
+
+class MetadataStatus:
+    def __init__(self, listener, obj, gid, status=""):
+        self.listener = listener
+        self._obj = obj
+        self._gid = gid
+        self._cstatus = status
+        self.engine = EngineStatus().STATUS_METADATA
+
+    def speed(self):
+        return f"{get_readable_file_size(self._obj.speed_raw)}/s"
+
+    def processed_bytes(self):
+        return get_readable_file_size(self._obj.processed_bytes)
+
+    def progress(self):
+        return f"{round(self._obj.progress_raw, 2)}%"
+
+    def gid(self):
+        return self._gid
+
+    def name(self):
+        return self.listener.name
+
+    def size(self):
+        return get_readable_file_size(self.listener.size)
+
+    def eta(self):
+        try:
+            eta_seconds = self._obj.eta_raw  # self._obj is an FFMpeg instance
+            if eta_seconds is not None and eta_seconds > 0:
+                return get_readable_time(eta_seconds)
+            return "-"
+        except Exception:
+            return "-"
+
+    def status(self):
+        if self._cstatus == "Convert":
+            return MirrorStatus.STATUS_CONVERT
+        else:
+            return MirrorStatus.STATUS_METADATA
+
+    def task(self):
+        return self
+
+    async def cancel_task(self):
+        LOGGER.info(f"Cancelling {self._cstatus}: {self.listener.name}")
+        self.listener.is_cancelled = True
+        if (
+            self.listener.subproc is not None
+            and self.listener.subproc.returncode is None
+        ):
+            try:
+                self.listener.subproc.kill()
+            except Exception:
+                pass
+        await self.listener.on_upload_error(f"{self._cstatus} stopped by user!")

--- a/bot/modules/metadata.py
+++ b/bot/modules/metadata.py
@@ -1,0 +1,138 @@
+from asyncio import create_subprocess_exec
+from asyncio.subprocess import PIPE
+from os import path as ospath, walk
+
+from aiofiles.os import path as aiopath, remove
+from aioshutil import move
+
+from .. import LOGGER, cpu_eater_lock, task_dict, task_dict_lock
+from ..core.config_manager import BinConfig
+from ..helper.ext_utils.bot_utils import sync_to_async
+from ..helper.ext_utils.files_utils import get_path_size
+from ..helper.ext_utils.media_utils import FFMpeg, get_document_type, get_media_info
+from ..helper.mirror_leech_utils.status_utils.metadata_status import MetadataStatus
+
+
+async def apply_metadata_title(self, dl_path, gid, metadata_dict):
+    if not metadata_dict:
+        return dl_path
+
+    LOGGER.info(f"Applying metadata: '{metadata_dict}' to {self.name}")
+    ffmpeg = FFMpeg(self)
+
+    is_file_input = await aiopath.isfile(dl_path)
+    files_to_process = []
+
+    if is_file_input:
+        is_video, is_audio, _ = await get_document_type(dl_path)
+        if is_video or is_audio:
+            files_to_process.append((dl_path, is_video, is_audio))
+        else:
+            LOGGER.info(f"Skipping metadata for non-audio/video file: {dl_path}")
+            return dl_path
+    else:
+        for dirpath, _, filenames in await sync_to_async(walk, dl_path, topdown=False):
+            for filename in filenames:
+                f_path = ospath.join(dirpath, filename)
+                is_video, is_audio, _ = await get_document_type(f_path)
+                if is_video or is_audio:
+                    files_to_process.append((f_path, is_video, is_audio))
+                else:
+                    LOGGER.info(f"Skipping metadata for non-audio/video file: {f_path}")
+
+    if not files_to_process:
+        LOGGER.info(f"No audio/video files found in {dl_path} to apply metadata.")
+        return dl_path
+
+    processed_one_successfully = False
+    original_dl_path_name = ospath.basename(dl_path) if is_file_input else dl_path
+
+    async with task_dict_lock:
+        task_dict[self.mid] = MetadataStatus(self, ffmpeg, gid, "up")
+
+    self.progress = False
+    await cpu_eater_lock.acquire()
+    self.progress = True
+
+    try:
+        for file_path, is_video, is_audio in files_to_process:
+            if self.is_cancelled:
+                break
+
+            self.subname = ospath.basename(file_path)
+            self.subsize = await get_path_size(file_path)
+
+            original_extension = ospath.splitext(file_path)[1]
+            temp_output_name = (
+                f"{ospath.splitext(file_path)[0]}.meta_temp{original_extension}"
+            )
+
+            base_cmd = [
+                BinConfig.FFMPEG_NAME,
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-i",
+                file_path,
+                "-map",
+                "0",
+            ]
+
+            for key, value in metadata_dict.items():
+                base_cmd.extend(["-metadata", f"{key}={value}"])
+
+            if is_video:
+                for key, value in metadata_dict.items():
+                    base_cmd.extend(
+                        [
+                            "-metadata:s:v",
+                            f"{key}={value}",
+                            "-metadata:s:a",
+                            f"{key}={value}",
+                            "-metadata:s:s",
+                            f"{key}={value}",
+                        ]
+                    )
+            elif is_audio:
+                for key, value in metadata_dict.items():
+                    base_cmd.extend(["-metadata:s:a", f"{key}={value}"])
+
+            cmd = base_cmd + ["-c", "copy", temp_output_name]
+
+            ffmpeg.clear()
+            media_info_tuple = await get_media_info(file_path)
+            if media_info_tuple:
+                ffmpeg._total_time = media_info_tuple[0]
+
+            self.subproc = await create_subprocess_exec(*cmd, stdout=PIPE, stderr=PIPE)
+            await ffmpeg._ffmpeg_progress()
+            _, stderr = await self.subproc.communicate()
+            return_code = self.subproc.returncode
+
+            if self.is_cancelled:
+                if await aiopath.exists(temp_output_name):
+                    await remove(temp_output_name)
+                break
+
+            if return_code == 0:
+                LOGGER.info(f"Successfully applied metadata to {file_path}")
+                await remove(file_path)
+                await move(temp_output_name, file_path)
+                if is_file_input and file_path == dl_path:
+                    original_dl_path_name = file_path
+                processed_one_successfully = True
+            else:
+                stderr_decoded = stderr.decode().strip()
+                LOGGER.error(
+                    f"Error applying metadata to {file_path}: {stderr_decoded}"
+                )
+                if await aiopath.exists(temp_output_name):
+                    await remove(temp_output_name)
+    finally:
+        cpu_eater_lock.release()
+
+    return (
+        original_dl_path_name
+        if is_file_input and processed_one_successfully
+        else dl_path
+    )

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -116,6 +116,7 @@ class Mirror(TaskListener):
             "link": "",
             "-n": "",
             "-m": "",
+            "-meta": "",
             "-up": "",
             "-rcf": "",
             "-au": "",
@@ -180,6 +181,23 @@ class Mirror(TaskListener):
         self.bot_trans = args["-bt"]
         self.user_trans = args["-ut"]
         self.is_yt = args["-yt"]
+
+        merged_metadata = self.default_metadata_dict.copy()
+
+        cmd_line_metadata_str = args["-meta"]
+        if cmd_line_metadata_str:
+            cmd_line_meta_dict = {}
+            pairs = cmd_line_metadata_str.split(":")
+            for pair in pairs:
+                if "=" in pair:
+                    key, value = pair.split("=", 1)
+                    cmd_line_meta_dict[key.strip()] = value.strip()
+                else:
+                    LOGGER.warning(f"Skipping malformed -meta argument pair: {pair}")
+
+            merged_metadata.update(cmd_line_meta_dict)
+
+        self.metadata_dict = merged_metadata
 
         headers = args["-h"]
         is_bulk = args["-b"]

--- a/bot/modules/ytdlp.py
+++ b/bot/modules/ytdlp.py
@@ -315,6 +315,7 @@ class YtDlp(TaskListener):
             "-sp": 0,
             "link": "",
             "-m": "",
+            "-meta": "",
             "-opt": {},
             "-n": "",
             "-up": "",
@@ -377,6 +378,23 @@ class YtDlp(TaskListener):
         self.folder_name = f"/{args["-m"]}".rstrip("/") if len(args["-m"]) > 0 else ""
         self.bot_trans = args["-bt"]
         self.user_trans = args["-ut"]
+
+        merged_metadata = self.default_metadata_dict.copy()
+
+        cmd_line_metadata_str = args["-meta"]
+        if cmd_line_metadata_str:
+            cmd_line_meta_dict = {}
+            pairs = cmd_line_metadata_str.split(":")
+            for pair in pairs:
+                if "=" in pair:
+                    key, value = pair.split("=", 1)
+                    cmd_line_meta_dict[key.strip()] = value.strip()
+                else:
+                    LOGGER.warning(f"Skipping malformed -meta argument pair: {pair}")
+
+            merged_metadata.update(cmd_line_meta_dict)
+
+        self.metadata_dict = merged_metadata
 
         is_bulk = args["-b"]
 


### PR DESCRIPTION
## Summary by Sourcery

Add metadata editing capability by allowing users to configure default metadata and override it per task, then automatically applying metadata tags to media files using FFmpeg.

New Features:
- Add a METADATA user setting and menu option to specify default metadata key=value pairs.
- Accept a `-meta` argument in mirror, leech, and ytdlp commands to override or extend default metadata for individual tasks.
- Introduce `apply_metadata_title` to inject metadata into audio/video files post-download and before upload.

Enhancements:
- Compute processed bytes and upload speed in FFmpeg progress reports to support metadata operations.
- Add a MetadataStatus class and integrate it into the task status system to track metadata application progress.

Chores:
- Update user settings UI, parsing logic, and display formatting to handle the METADATA option.
- Merge default and task-level metadata in common task initialization and propagate it through modules.