### PR TITLE
feat: Add nuke all previous metadata

### DIFF
--- a/bot/modules/metadata.py
+++ b/bot/modules/metadata.py
@@ -76,6 +76,8 @@ async def apply_metadata_title(self, dl_path, gid, metadata_dict):
                 file_path,
                 "-map",
                 "0",
+                "-map_metadata",
+                "-1",
             ]
 
             for key, value in metadata_dict.items():


### PR DESCRIPTION
## Summary by Sourcery

New Features:
- Add `-map_metadata -1` flags to the ffmpeg invocation to strip existing metadata before applying new metadata