### PR TITLE
fix: EXCLUDED_EXTENSIONS error

### DIFF
--- a/bot/core/startup.py
+++ b/bot/core/startup.py
@@ -238,10 +238,10 @@ async def update_variables():
             sudo_users.append(int(id_.strip()))
 
     if Config.EXCLUDED_EXTENSIONS:
-        fx = Config.EXCLUDED_EXTENSIONS.split()
-        for x in fx:
-            x = x.lstrip(".")
-            excluded_extensions.append(x.strip().lower())
+        excluded_extensions.clear()
+        excluded_extensions.extend(
+            parse_excluded_extensions(Config.EXCLUDED_EXTENSIONS)
+        )
 
     if Config.GDRIVE_ID:
         drives_names.append("Main")

--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -307,3 +307,12 @@ def loop_thread(func):
         return future.result() if wait else future
 
     return wrapper
+
+
+def parse_excluded_extensions(val):
+    """Parse EXCLUDED_EXTENSIONS from any input to a clean list of extensions."""
+    if not val:
+        return []
+    if isinstance(val, str):
+        val = val.replace(",", " ").split()
+    return [x.lstrip(".").strip().lower() for x in val if x.strip()]

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -44,6 +44,7 @@ from ..core.startup import update_qb_options, update_nzb_options, update_variabl
 from ..helper.ext_utils.db_handler import database
 from ..core.jdownloader_booter import jdownloader
 from ..helper.ext_utils.task_manager import start_from_queued
+from ..helper.ext_utils.bot_utils import parse_excluded_extensions
 from ..helper.mirror_leech_utils.rclone_utils.serve import rclone_serve_booter
 from ..helper.telegram_helper.button_build import ButtonMaker
 from ..helper.telegram_helper.message_utils import (
@@ -297,12 +298,9 @@ async def edit_variable(_, message, pre_message, key):
                 f"gunicorn -k uvicorn.workers.UvicornWorker -w 1 web.wserver:app --bind 0.0.0.0:{value}"
             )
     elif key == "EXCLUDED_EXTENSIONS":
-        fx = value.split()
         excluded_extensions.clear()
         excluded_extensions.extend(["aria2", "!qB"])
-        for x in fx:
-            x = x.lstrip(".")
-            excluded_extensions.append(x.strip().lower())
+        excluded_extensions.extend(parse_excluded_extensions(value))
     elif key == "GDRIVE_ID":
         if drives_names and drives_names[0] == "Main":
             drives_ids[0] = value

--- a/bot/modules/users_settings.py
+++ b/bot/modules/users_settings.py
@@ -31,6 +31,7 @@ from ..helper.telegram_helper.message_utils import (
     send_file,
     send_message,
 )
+from ..helper.ext_utils.bot_utils import parse_excluded_extensions
 
 handler_dict = {}
 
@@ -595,15 +596,14 @@ async def get_user_settings(from_user, stype="main"):
         buttons.data_button(
             "Excluded Extensions", f"userset {user_id} menu EXCLUDED_EXTENSIONS"
         )
-        if user_dict.get("EXCLUDED_EXTENSIONS", False):
-            ex_ex = user_dict["EXCLUDED_EXTENSIONS"]
+        ex_ex = user_dict.get("EXCLUDED_EXTENSIONS")
+        if ex_ex:
+            ex_ex = parse_excluded_extensions(ex_ex)
         elif "EXCLUDED_EXTENSIONS" not in user_dict:
             ex_ex = excluded_extensions
         else:
-            ex_ex = "None"
-
-        if ex_ex != "None":
-            ex_ex = ", ".join(ex_ex)
+            ex_ex = []
+        displayed = ", ".join(ex_ex) if ex_ex else "None"
 
         ns_msg = (
             f"<code>{swap}</code>"


### PR DESCRIPTION
## Summary by Sourcery

Introduce a dedicated parser for EXCLUDED_EXTENSIONS and replace scattered ad-hoc parsing logic with the new helper across startup, user settings display, and bot settings editing.

Enhancements:
- Add parse_excluded_extensions helper to normalize EXCLUDED_EXTENSIONS into a consistent list
- Refactor startup sequence to clear and repopulate excluded_extensions via the new parser
- Update user settings display to leverage the parser and streamline extension list formatting
- Simplify bot settings edit flow for EXCLUDED_EXTENSIONS by using the parser