### PR TITLE
Minor revert

### DIFF
--- a/bot/core/startup.py
+++ b/bot/core/startup.py
@@ -239,10 +239,10 @@ async def update_variables():
             sudo_users.append(int(id_.strip()))
 
     if Config.EXCLUDED_EXTENSIONS:
-        excluded_extensions.clear()
-        excluded_extensions.extend(
-            parse_excluded_extensions(Config.EXCLUDED_EXTENSIONS)
-        )
+        fx = Config.EXCLUDED_EXTENSIONS.split()
+        for x in fx:
+            x = x.lstrip(".")
+            excluded_extensions.append(x.strip().lower())
 
     if Config.GDRIVE_ID:
         drives_names.append("Main")

--- a/bot/core/startup.py
+++ b/bot/core/startup.py
@@ -29,7 +29,7 @@ from ..helper.ext_utils.db_handler import database
 from .config_manager import Config, BinConfig
 from .tg_client import TgClient
 from .torrent_manager import TorrentManager
-from ..helper.ext_utils.bot_utils import parse_excluded_extensions
+
 
 
 async def update_qb_options():

--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -307,12 +307,3 @@ def loop_thread(func):
         return future.result() if wait else future
 
     return wrapper
-
-
-def parse_excluded_extensions(val):
-    """Parse EXCLUDED_EXTENSIONS from any input to a clean list of extensions."""
-    if not val:
-        return []
-    if isinstance(val, str):
-        val = val.replace(",", " ").split()
-    return [x.lstrip(".").strip().lower() for x in val if x.strip()]

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -44,7 +44,6 @@ from ..core.startup import update_qb_options, update_nzb_options, update_variabl
 from ..helper.ext_utils.db_handler import database
 from ..core.jdownloader_booter import jdownloader
 from ..helper.ext_utils.task_manager import start_from_queued
-from ..helper.ext_utils.bot_utils import parse_excluded_extensions
 from ..helper.mirror_leech_utils.rclone_utils.serve import rclone_serve_booter
 from ..helper.telegram_helper.button_build import ButtonMaker
 from ..helper.telegram_helper.message_utils import (
@@ -298,9 +297,12 @@ async def edit_variable(_, message, pre_message, key):
                 f"gunicorn -k uvicorn.workers.UvicornWorker -w 1 web.wserver:app --bind 0.0.0.0:{value}"
             )
     elif key == "EXCLUDED_EXTENSIONS":
+        fx = value.split()
         excluded_extensions.clear()
         excluded_extensions.extend(["aria2", "!qB"])
-        excluded_extensions.extend(parse_excluded_extensions(value))
+        for x in fx:
+            x = x.lstrip(".")
+            excluded_extensions.append(x.strip().lower())
     elif key == "GDRIVE_ID":
         if drives_names and drives_names[0] == "Main":
             drives_ids[0] = value

--- a/bot/modules/users_settings.py
+++ b/bot/modules/users_settings.py
@@ -31,7 +31,6 @@ from ..helper.telegram_helper.message_utils import (
     send_file,
     send_message,
 )
-from ..helper.ext_utils.bot_utils import parse_excluded_extensions
 
 handler_dict = {}
 
@@ -596,14 +595,15 @@ async def get_user_settings(from_user, stype="main"):
         buttons.data_button(
             "Excluded Extensions", f"userset {user_id} menu EXCLUDED_EXTENSIONS"
         )
-        ex_ex = user_dict.get("EXCLUDED_EXTENSIONS")
-        if ex_ex:
-            ex_ex = parse_excluded_extensions(ex_ex)
+        if user_dict.get("EXCLUDED_EXTENSIONS", False):
+            ex_ex = user_dict["EXCLUDED_EXTENSIONS"]
         elif "EXCLUDED_EXTENSIONS" not in user_dict:
             ex_ex = excluded_extensions
         else:
-            ex_ex = []
-        displayed = ", ".join(ex_ex) if ex_ex else "None"
+            ex_ex = "None"
+
+        if ex_ex != "None":
+            ex_ex = ", ".join(ex_ex)
 
         ns_msg = (
             f"<code>{swap}</code>"


### PR DESCRIPTION
## Summary by Sourcery

Inline the parsing of EXCLUDED_EXTENSIONS across modules, remove the now-unused parse_excluded_extensions helper, and update user settings display logic to show “None” when no extensions are set.

Enhancements:
- Remove the parse_excluded_extensions function and its imports.
- Inline EXCLUDED_EXTENSIONS parsing in startup, bot settings, and user settings using string splitting, dot-stripping, and lowercase normalization.
- Update user settings display to default to “None” when no extensions are configured and join the list only when present.