### PR TITLE
Fix error when torrent_disabled

### DIFF
--- a/bot/core/torrent_manager.py
+++ b/bot/core/torrent_manager.py
@@ -83,10 +83,15 @@ class TorrentManager:
     @classmethod
     async def remove_all(cls):
         await cls.pause_all()
-        await gather(
+        if cls.qbittorrent:
+            await gather(
             cls.qbittorrent.torrents.delete("all", False),
             cls.aria2.purgeDownloadResult(),
-        )
+            )
+        else:
+            await gather(
+            cls.aria2.purgeDownloadResult(),
+            )
         downloads = []
         results = await gather(cls.aria2.tellActive(), cls.aria2.tellWaiting(0, 1000))
         for res in results:


### PR DESCRIPTION
Refactor remove_all method to handle qbittorrent conditionally.

## Summary by Sourcery

Refactor remove_all to conditionally invoke qbittorrent operations only when the client is enabled, avoiding errors when qbittorrent is disabled.

Bug Fixes:
- Prevent errors in remove_all by skipping qbittorrent.torrents.delete when the qbittorrent client is not configured

Enhancements:
- Simplify purge logic to always invoke aria2.purgeDownloadResult regardless of qbittorrent status