### PR TITLE
Fix ValueError for empty task limits

### DIFF
--- a/bot/helper/ext_utils/task_manager.py
+++ b/bot/helper/ext_utils/task_manager.py
@@ -268,13 +268,13 @@ async def pre_task_check(message):
         msg.append(
             f"┠ <b>Waiting Time</b> → {get_readable_time(ut)}\n┠ <i>User's Time Interval Restrictions</i> → {get_readable_time(uti)}"
         )
-    bmax_tasks = int(Config.BOT_MAX_TASKS)
+    bmax_tasks = int(Config.BOT_MAX_TASKS or 0)
     if bmax_tasks > 0 and len(await get_specific_tasks("All", False)) >= bmax_tasks:
         msg.append(
             f"┠ Max Concurrent Bot's Tasks Limit exceeded.\n┠ Bot Tasks Limit : {bmax_tasks} task"
         )
 
-    maxtask = int(Config.USER_MAX_TASKS)
+    maxtask = int(Config.USER_MAX_TASKS or 0)
     if maxtask > 0 and len(await get_specific_tasks("All", user_id)) >= maxtask:
         msg.append(
             f"┠ Max Concurrent User's Task(s) Limit exceeded! \n┠ User Task Limit : {maxtask} tasks"


### PR DESCRIPTION
Previously, if `Config.BOT_MAX_TASKS` or `Config.USER_MAX_TASKS` were set to an empty string, the application would crash with a `ValueError` when trying to cast the empty string to an integer.

This commit fixes the issue by providing a default value of 0 when these configuration variables are empty. This is achieved by using `or 0` before the type conversion, ensuring that an empty string is treated as 0, thus preventing the crash.