### PR TITLE
fix: get tag in rss and key error in rm sudo

### DIFF
--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -502,7 +502,7 @@ class TaskConfig:
                 self.tag = " ".join(user_info[:-1])
             else:
                 self.tag, id_ = text[1].split("Tag: ")[1].split()
-            self.user = self.message.from_user = await self.client.get_users(id_)
+            self.user = self.message.from_user = await self.client.get_users(int(id_))
             self.user_id = self.user.id
             self.user_dict = user_data.get(self.user_id, {})
             with suppress(Exception):

--- a/bot/modules/chat_permission.py
+++ b/bot/modules/chat_permission.py
@@ -98,10 +98,13 @@ async def remove_sudo(_, message):
         id_ = int(msg[1].strip())
     elif reply_to := message.reply_to_message:
         id_ = (reply_to.from_user or reply_to.sender_chat).id
-    if id_ and id_ not in user_data or user_data[id_].get("SUDO"):
-        update_user_ldata(id_, "SUDO", False)
-        await database.update_user_data(id_)
-        msg = "Demoted"
+    if id_:
+        if id_ in user_data and user_data[id_].get("SUDO"):
+            update_user_ldata(id_, "SUDO", False)
+            await database.update_user_data(id_)
+            msg = "Demoted"
+        else:
+            msg = "Already Not Sudo! Sudo users added from config must be removed from config."
     else:
         msg = "Give ID or Reply To message of whom you want to remove from Sudo"
     await send_message(message, msg)


### PR DESCRIPTION
## Summary by Sourcery

Improve error handling in the remove_sudo command and fix type conversion for user lookup in get_tag

Bug Fixes:
- Prevent KeyError in remove_sudo by checking for existing user_data entries and providing clear feedback when attempting to demote a non-sudo user
- Cast the extracted ID to an integer in get_tag before calling get_users to avoid type errors