### PR TITLE
Enhance type conversion in config manager

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -126,6 +126,7 @@ class Config:
     @classmethod
     def set(cls, key, value):
         if hasattr(cls, key):
+            value = cls._convert_env_type(key, value)
             setattr(cls, key, value)
         else:
             raise KeyError(f"{key} is not a valid configuration key.")
@@ -195,16 +196,22 @@ class Config:
         if original_value is None:
             return value
         elif isinstance(original_value, bool):
-            return value.lower() in ("true", "1", "yes")
+            if isinstance(value, bool):
+                return value
+            return str(value).lower() in ("true", "1", "yes")
         elif isinstance(original_value, int):
+            if isinstance(value, int):
+                return value
             try:
                 return int(value)
-            except ValueError:
+            except (ValueError, TypeError):
                 return original_value
         elif isinstance(original_value, float):
+            if isinstance(value, float):
+                return value
             try:
                 return float(value)
-            except ValueError:
+            except (ValueError, TypeError):
                 return original_value
         return value
 
@@ -228,6 +235,7 @@ class Config:
                             value = []
                     except Exception:
                         value = []
+                value = cls._convert_env_type(key, value)
                 setattr(cls, key, value)
         for key in ["BOT_TOKEN", "OWNER_ID", "TELEGRAM_API", "TELEGRAM_HASH"]:
             value = getattr(cls, key)


### PR DESCRIPTION
## Summary by Sourcery

Enhance config_manager to coerce environment and loaded values to their original types and improve resilience against invalid inputs

Enhancements:
- Apply _convert_env_type in set() and load_dict() to ensure configuration values match their default types
- Extend _convert_env_type to return values unchanged when already of the correct type for bool, int, and float
- Catch TypeError as well as ValueError during numeric conversions to fall back to defaults gracefully