### PR TITLE
feat: selectable leech dump chat per task via -du flag

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -88,7 +88,8 @@ class Config:
     EXTRACT_LIMIT = 0
     ARCHIVE_LIMIT = 0
     STORAGE_LIMIT = 0
-    LEECH_DUMP_CHAT = ""
+    LEECH_LOG_CHAT = ""
+    LEECH_DUMP_CHATS = {}
     LINKS_LOG_ID = ""
     MIRROR_LOG_ID = ""
     LEECH_PREFIX = ""
@@ -216,6 +217,12 @@ class Config:
                     except Exception:
                         continue
                 setattr(cls, attr, value)
+        if hasattr(settings, "LEECH_DUMP_CHAT"):
+            legacy_value = getattr(settings, "LEECH_DUMP_CHAT")
+            if legacy_value and not cls.LEECH_LOG_CHAT:
+                if isinstance(legacy_value, str):
+                    legacy_value = legacy_value.strip()
+                cls.LEECH_LOG_CHAT = legacy_value
         for key in ["BOT_TOKEN", "OWNER_ID", "TELEGRAM_API", "TELEGRAM_HASH"]:
             value = getattr(cls, key)
             if isinstance(value, str):
@@ -225,6 +232,11 @@ class Config:
 
     @classmethod
     def load_env(cls):
+        legacy_dump_chat = getenv("LEECH_DUMP_CHAT")
+        if legacy_dump_chat is not None and getenv("LEECH_LOG_CHAT") is None:
+            cls.LEECH_LOG_CHAT = cls._convert_env_type(
+                "LEECH_LOG_CHAT", legacy_dump_chat
+            )
         config_vars = cls.get_all()
         for key in config_vars:
             env_value = getenv(key)
@@ -304,6 +316,10 @@ class Config:
                         value = []
                 value = cls._convert_env_type(key, value)
                 setattr(cls, key, value)
+        if config_dict.get("LEECH_DUMP_CHAT") and not cls.LEECH_LOG_CHAT:
+            cls.LEECH_LOG_CHAT = cls._convert_env_type(
+                "LEECH_LOG_CHAT", config_dict["LEECH_DUMP_CHAT"]
+            )
         for key in ["BOT_TOKEN", "OWNER_ID", "TELEGRAM_API", "TELEGRAM_HASH"]:
             value = getattr(cls, key)
             if isinstance(value, str):

--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -84,6 +84,7 @@ class Config:
     ARCHIVE_LIMIT = 0
     STORAGE_LIMIT = 0
     LEECH_DUMP_CHAT = ""
+    LEECH_DUMP_CHATS = {}
     LINKS_LOG_ID = ""
     MIRROR_LOG_ID = ""
     LEECH_PREFIX = ""

--- a/bot/core/handlers.py
+++ b/bot/core/handlers.py
@@ -433,6 +433,9 @@ async def add_handlers():
         CallbackQueryHandler(confirm_category, filters=regex("^scat"))
     )
     TgClient.bot.add_handler(
+        CallbackQueryHandler(confirm_dump_chat, filters=regex("^sdump"))
+    )
+    TgClient.bot.add_handler(
         MessageHandler(
             drive_clean,
             filters=command(BotCommands.GDCleanCommand, case_sensitive=True)

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -65,6 +65,7 @@ from .telegram_helper.bot_commands import BotCommands
 from .telegram_helper.message_utils import (
     get_tg_link_message,
     open_category_btns,
+    open_dump_chat_btns,
     send_message,
     send_status_message,
 )
@@ -96,6 +97,7 @@ class TaskConfig:
         self.drive_id = ""
         self.leech_dest = ""
         self.cmd_up_dest = ""
+        self.dump_dest = ""
         self.rc_flags = ""
         self.tag = ""
         self.name = ""
@@ -496,7 +498,29 @@ class TaskConfig:
             if self.hybrid_leech:
                 self.transmission_mode = "both"
 
-            self.up_dest = Config.LEECH_DUMP_CHAT
+            self.up_dest = Config.LEECH_LOG_CHAT
+            if self.dump_dest:
+                dump_chats = Config.LEECH_DUMP_CHATS or {}
+                self.up_dest = dump_chats.get(self.dump_dest)
+                if self.up_dest is None:
+                    raw_id = str(self.dump_dest).lstrip("-").isdigit()
+                    if raw_id or self.dump_dest.startswith("@"):
+                        self.up_dest = self.dump_dest
+                    elif dump_chats:
+                        up_dest, is_cancelled = await open_dump_chat_btns(
+                            self.message, dump_chats, self.dump_dest
+                        )
+                        if is_cancelled:
+                            self.is_cancelled = True
+                            return
+                        if not up_dest:
+                            raise ValueError("No dump chat selected!")
+                        self.up_dest = up_dest
+                    else:
+                        raise ValueError(
+                            f"Unknown dump chat '{self.dump_dest}'! "
+                            f"Configured dumps: none"
+                        )
             if self.up_dest:
                 if not isinstance(self.up_dest, int):
                     if "|" in str(self.up_dest):

--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -96,6 +96,7 @@ class TaskConfig:
         self.drive_id = ""
         self.leech_dest = ""
         self.cmd_up_dest = ""
+        self.dump_dest = ""
         self.rc_flags = ""
         self.tag = ""
         self.name = ""
@@ -494,6 +495,18 @@ class TaskConfig:
                 self.transmission_mode = "both"
 
             self.up_dest = Config.LEECH_DUMP_CHAT
+            if self.dump_dest:
+                dump_chats = Config.LEECH_DUMP_CHATS or {}
+                self.up_dest = dump_chats.get(self.dump_dest)
+                if self.up_dest is None:
+                    raw_id = str(self.dump_dest).lstrip("-").isdigit()
+                    if raw_id or self.dump_dest.startswith("@"):
+                        self.up_dest = self.dump_dest
+                    else:
+                        raise ValueError(
+                            f"Unknown dump chat '{self.dump_dest}'! "
+                            f"Configured dumps: {', '.join(dump_chats) or 'none'}"
+                        )
             if self.up_dest:
                 if not isinstance(self.up_dest, int):
                     if "|" in str(self.up_dest):

--- a/bot/helper/ext_utils/hyperul_utils.py
+++ b/bot/helper/ext_utils/hyperul_utils.py
@@ -117,7 +117,7 @@ class HypertgUpload(HypertgTransfer):
         upload_chat_id = (
             self._listener.up_dest
             if self._listener.up_dest
-            else (Config.LEECH_DUMP_CHAT or reply_target.chat.id)
+            else (Config.LEECH_LOG_CHAT or reply_target.chat.id)
         )
         try:
             if use_hyper:

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -455,8 +455,8 @@ class TaskListener(TaskConfig):
             button = buttons.build_menu(1) if link else None
 
             await send_message(self.user_id, msg, button)
-            if Config.LEECH_DUMP_CHAT:
-                await send_message(Config.LEECH_DUMP_CHAT, msg, button)
+            if Config.LEECH_LOG_CHAT:
+                await send_message(Config.LEECH_LOG_CHAT, msg, button)
             await send_message(self.message, user_message, button)
 
         elif self.is_leech:
@@ -481,7 +481,7 @@ class TaskListener(TaskConfig):
                 for index, (link, name) in enumerate(files.items(), start=1):
                     fmsg += f"{index}. <a href='{link}'>{name}</a>"
                     if Config.MEDIA_STORE and (
-                        self.is_super_chat or Config.LEECH_DUMP_CHAT
+                        self.is_super_chat or Config.LEECH_LOG_CHAT
                     ):
                         parts = link.split("/")[-2:]
                         if len(parts) == 2:

--- a/bot/helper/mirror_leech_utils/download_utils/telegram_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/telegram_download.py
@@ -36,7 +36,7 @@ class TelegramDownloadHelper:
         tm = self._listener.transmission_mode
         self._hyper_dl = (
             Config.USE_HYPER
-            and Config.LEECH_DUMP_CHAT
+            and (Config.LEECH_LOG_CHAT or self._listener.up_dest)
             and (
                 (tm in ("bot", "both") and len(TgClient.helper_bots) != 0)
                 or (
@@ -103,7 +103,7 @@ class TelegramDownloadHelper:
                     download = await self._hyper_dl_instance.download_media(
                         message,
                         file_name=path,
-                        dump_chat=Config.LEECH_DUMP_CHAT,
+                        dump_chat=self._listener.up_dest or Config.LEECH_LOG_CHAT,
                     )
                     if (
                         self._hyper_dl_instance is not None

--- a/bot/helper/mirror_leech_utils/download_utils/telegram_download.py
+++ b/bot/helper/mirror_leech_utils/download_utils/telegram_download.py
@@ -36,7 +36,7 @@ class TelegramDownloadHelper:
         tm = self._listener.transmission_mode
         self._hyper_dl = (
             Config.USE_HYPER
-            and Config.LEECH_DUMP_CHAT
+            and (Config.LEECH_DUMP_CHAT or self._listener.up_dest)
             and (
                 (tm in ("bot", "both") and len(TgClient.helper_bots) != 0)
                 or (
@@ -103,7 +103,7 @@ class TelegramDownloadHelper:
                     download = await self._hyper_dl_instance.download_media(
                         message,
                         file_name=path,
-                        dump_chat=Config.LEECH_DUMP_CHAT,
+                        dump_chat=self._listener.up_dest or Config.LEECH_DUMP_CHAT,
                     )
                     if (
                         self._hyper_dl_instance is not None

--- a/bot/helper/telegram_helper/message_utils.py
+++ b/bot/helper/telegram_helper/message_utils.py
@@ -581,3 +581,52 @@ async def open_drive_clean(message):
         await edit_message(prompt, "<b>Task Cancelled</b>")
     del bot_cache[msg_id]
     return drive_id, is_cancelled, cat_name
+
+
+async def open_dump_chat_btns(message, dump_chats, invalid_name=None):
+    user_id = message.from_user.id
+    msg_id = message.id
+    cache_key = f"sdump_{msg_id}"
+    buttons = ButtonMaker()
+    dump_names = list(dump_chats)
+    selected_name = dump_names[0] if dump_names else None
+    for i, name in enumerate(dump_names):
+        buttons.data_button(
+            f"{'✓️' if i == 0 else ''} {name}",
+            f"sdump {user_id} {msg_id} {name.replace(' ', '_')}",
+        )
+    buttons.data_button(
+        "Cancel",
+        f"sdump {user_id} {msg_id} scancel",
+        "footer",
+        style=ButtonStyle.DANGER,
+    )
+    buttons.data_button(
+        "Done (60)",
+        f"sdump {user_id} {msg_id} sdone",
+        "footer",
+        style=ButtonStyle.SUCCESS,
+    )
+    invalid_hint = (
+        f"\n\n<b>Unknown dump:</b> <code>{invalid_name}</code>" if invalid_name else ""
+    )
+    prompt = await send_message(
+        message,
+        f"<b>Select the dump chat for this task</b>{invalid_hint}\n\n"
+        f"<i><b>Dump Chat:</b></i> <code>{selected_name or 'None'}</code>\n\n"
+        f"<b>Timeout:</b> 60 sec",
+        buttons.build_menu(3),
+    )
+    start_time = time()
+    bot_cache[cache_key] = [dump_chats.get(selected_name), False, False, start_time]
+    while time() - start_time <= 60:
+        await sleep(0.5)
+        if bot_cache[cache_key][1] or bot_cache[cache_key][2]:
+            break
+    up_dest, _, is_cancelled, __ = bot_cache[cache_key]
+    if not is_cancelled:
+        await delete_message(prompt)
+    else:
+        await edit_message(prompt, "<b>Task Cancelled</b>")
+    del bot_cache[cache_key]
+    return up_dest, is_cancelled

--- a/bot/modules/__init__.py
+++ b/bot/modules/__init__.py
@@ -21,7 +21,7 @@ from .help import arg_usage, bot_help
 from .images import picture_add, pictures, pics_callback
 from .mediainfo import mediainfo
 from .stream import stream_links
-from .category_select import change_category, confirm_category
+from .category_select import change_category, confirm_category, confirm_dump_chat
 from .broadcast import broadcast
 from .mirror_leech import (
     mirror,
@@ -113,6 +113,7 @@ __all__ = [
     "broadcast",
     "change_category",
     "confirm_category",
+    "confirm_dump_chat",
     "ping",
     "log",
     "log_cb",

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -194,7 +194,8 @@ DEFAULT_DESP = {
     "EXTRACT_LIMIT": "Extracted file size limit in GB. 0 = unlimited.",
     "ARCHIVE_LIMIT": "Archive (zip) size limit in GB. 0 = unlimited.",
     "STORAGE_LIMIT": "Minimum free storage to maintain in GB. Downloads cancelled if exceeded.",
-    "LEECH_DUMP_CHAT": "Chat ID (integer) to dump all leeched files. Leave empty to disable.",
+    "LEECH_LOG_CHAT": "Chat ID (integer) for leech log messages. Leave empty to disable.",
+    "LEECH_DUMP_CHATS": 'Named leech dump chats selectable per task via -ud flag. Dict format: {"name": chat_id}. Example: {"A": -100123}.',
     "LINKS_LOG_ID": "Chat ID for link logging.",
     "MIRROR_LOG_ID": "Chat ID(s) for mirror logs. Space-separated for multiple.",
     "LEECH_PREFIX": "Prefix added to leeched file names.",
@@ -604,16 +605,35 @@ async def edit_variable(_, message, pre_message, key):
                     "Invalid value! MIRROR_LOG_ID must be a valid integer chat ID.",
                 )
                 return await update_buttons(pre_message, "var")
-    elif key == "LEECH_DUMP_CHAT":
+    elif key == "LEECH_LOG_CHAT":
         if value.strip():
             try:
                 value = int(value.strip())
             except ValueError:
                 await send_message(
                     message,
-                    "Invalid value! LEECH_DUMP_CHAT must be a valid integer chat ID.",
+                    "Invalid value! LEECH_LOG_CHAT must be a valid integer chat ID.",
                 )
                 return await update_buttons(pre_message, "var")
+    elif key == "LEECH_DUMP_CHATS":
+        if isinstance(value, str):
+            if value.startswith("{") and value.endswith("}"):
+                try:
+                    value = literal_eval(value)
+                except Exception:
+                    await send_message(message, "Invalid dict format!")
+                    return
+            else:
+                await send_message(
+                    message,
+                    'LEECH_DUMP_CHATS must be a dict. Format: {"A": -100123456}',
+                )
+                return
+        if not isinstance(value, dict):
+            await send_message(
+                message, 'LEECH_DUMP_CHATS must be a dict. Format: {"A": -100123456}'
+            )
+            return
     elif key == "AUTHORIZED_CHATS":
         aid = value.split()
         auth_chats.clear()

--- a/bot/modules/bot_settings.py
+++ b/bot/modules/bot_settings.py
@@ -188,6 +188,7 @@ DEFAULT_DESP = {
     "ARCHIVE_LIMIT": "Archive (zip) size limit in GB. 0 = unlimited.",
     "STORAGE_LIMIT": "Minimum free storage to maintain in GB. Downloads cancelled if exceeded.",
     "LEECH_DUMP_CHAT": "Chat ID (integer) to dump all leeched files. Leave empty to disable.",
+    "LEECH_DUMP_CHATS": 'Named leech dump chats selectable per task via -du flag. Dict format: {"name": chat_id}. Example: {"A": -100123}.',
     "LINKS_LOG_ID": "Chat ID for link logging.",
     "MIRROR_LOG_ID": "Chat ID(s) for mirror logs. Space-separated for multiple.",
     "LEECH_PREFIX": "Prefix added to leeched file names.",
@@ -599,6 +600,25 @@ async def edit_variable(_, message, pre_message, key):
                     "Invalid value! LEECH_DUMP_CHAT must be a valid integer chat ID.",
                 )
                 return await update_buttons(pre_message, "var")
+    elif key == "LEECH_DUMP_CHATS":
+        if isinstance(value, str):
+            if value.startswith("{") and value.endswith("}"):
+                try:
+                    value = literal_eval(value)
+                except Exception:
+                    await send_message(message, "Invalid dict format!")
+                    return
+            else:
+                await send_message(
+                    message,
+                    'LEECH_DUMP_CHATS must be a dict. Format: {"A": -100123456}',
+                )
+                return
+        if not isinstance(value, dict):
+            await send_message(
+                message, 'LEECH_DUMP_CHATS must be a dict. Format: {"A": -100123456}'
+            )
+            return
     elif key == "AUTHORIZED_CHATS":
         aid = value.split()
         auth_chats.clear()

--- a/bot/modules/category_select.py
+++ b/bot/modules/category_select.py
@@ -157,3 +157,52 @@ async def confirm_category(client, query):
         f"<b>Timeout:</b> 60 sec",
         buttons.build_menu(3),
     )
+
+
+@new_task
+async def confirm_dump_chat(client, query):
+    user_id = query.from_user.id
+    data = query.data.split(maxsplit=3)
+    msg_id = int(data[2])
+    cache_key = f"sdump_{msg_id}"
+    if cache_key not in bot_cache:
+        return await edit_message(query.message, "<b>Old Task</b>")
+    elif user_id != int(data[1]) and not await CustomFilters.sudo("", query):
+        return await query.answer(text="This task is not for you!", show_alert=True)
+    elif data[3] == "sdone":
+        bot_cache[cache_key][1] = True
+        return
+    elif data[3] == "scancel":
+        bot_cache[cache_key][2] = True
+        return
+    await query.answer()
+    dump_chats = Config.LEECH_DUMP_CHATS or {}
+    dump_name = data[3].replace("_", " ")
+    if dump_name not in dump_chats:
+        return
+    bot_cache[cache_key][0] = dump_chats[dump_name]
+    buttons = ButtonMaker()
+    for name in dump_chats:
+        buttons.data_button(
+            f"{'✓️' if dump_name == name else ''} {name}",
+            f"sdump {user_id} {msg_id} {name.replace(' ', '_')}",
+        )
+    buttons.data_button(
+        "Cancel",
+        f"sdump {user_id} {msg_id} scancel",
+        "footer",
+        style=ButtonStyle.DANGER,
+    )
+    buttons.data_button(
+        f"Done ({get_readable_time(60 - (time() - bot_cache[cache_key][3]))})",
+        f"sdump {user_id} {msg_id} sdone",
+        "footer",
+        style=ButtonStyle.SUCCESS,
+    )
+    await edit_message(
+        query.message,
+        f"<b>Select the dump chat for this task</b>\n\n"
+        f"<i><b>Dump Chat:</b></i> <code>{dump_name}</code>\n\n"
+        f"<b>Timeout:</b> 60 sec",
+        buttons.build_menu(3),
+    )

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -141,6 +141,7 @@ class Mirror(TaskListener):
             "-m": "",
             "-meta": "",
             "-up": "",
+            "-ud": "",
             "-gc": "",
             "-rcf": "",
             "-au": "",
@@ -182,6 +183,7 @@ class Mirror(TaskListener):
         self.seed = args["-d"]
         self.name = args["-n"]
         self.up_dest = args["-up"]
+        self.dump_dest = args["-ud"]
         self.category = args["-gc"]
         self.rc_flags = args["-rcf"]
         self.link = args["link"]

--- a/bot/modules/mirror_leech.py
+++ b/bot/modules/mirror_leech.py
@@ -122,6 +122,7 @@ class Mirror(TaskListener):
             "-m": "",
             "-meta": "",
             "-up": "",
+            "-du": "",
             "-gc": "",
             "-rcf": "",
             "-au": "",
@@ -163,6 +164,7 @@ class Mirror(TaskListener):
         self.seed = args["-d"]
         self.name = args["-n"]
         self.up_dest = args["-up"]
+        self.dump_dest = args["-du"]
         self.category = args["-gc"]
         self.rc_flags = args["-rcf"]
         self.link = args["link"]

--- a/bot/modules/users_settings.py
+++ b/bot/modules/users_settings.py
@@ -441,8 +441,8 @@ async def get_user_settings(from_user, stype="main"):
         )
         if user_dict.get("LEECH_DUMP_CHAT", False):
             leech_dest = user_dict["LEECH_DUMP_CHAT"]
-        elif "LEECH_DUMP_CHAT" not in user_dict and Config.LEECH_DUMP_CHAT:
-            leech_dest = Config.LEECH_DUMP_CHAT
+        elif "LEECH_DUMP_CHAT" not in user_dict and Config.LEECH_LOG_CHAT:
+            leech_dest = Config.LEECH_LOG_CHAT
         else:
             leech_dest = "None"
         buttons.data_button("Leech Prefix", f"userset {user_id} menu LEECH_PREFIX")

--- a/bot/modules/ytdlp.py
+++ b/bot/modules/ytdlp.py
@@ -321,6 +321,7 @@ class YtDlp(TaskListener):
             "-opt": {},
             "-n": "",
             "-up": "",
+            "-ud": "",
             "-gc": "",
             "-rcf": "",
             "-t": "",
@@ -366,6 +367,7 @@ class YtDlp(TaskListener):
         self.select = args["-s"]
         self.name = args["-n"]
         self.up_dest = args["-up"]
+        self.dump_dest = args["-ud"]
         self.category = args["-gc"]
         self.rc_flags = args["-rcf"]
         self.link = args["link"]

--- a/bot/modules/ytdlp.py
+++ b/bot/modules/ytdlp.py
@@ -321,6 +321,7 @@ class YtDlp(TaskListener):
             "-opt": {},
             "-n": "",
             "-up": "",
+            "-du": "",
             "-gc": "",
             "-rcf": "",
             "-t": "",
@@ -366,6 +367,7 @@ class YtDlp(TaskListener):
         self.select = args["-s"]
         self.name = args["-n"]
         self.up_dest = args["-up"]
+        self.dump_dest = args["-du"]
         self.category = args["-gc"]
         self.rc_flags = args["-rcf"]
         self.link = args["link"]

--- a/config_sample.py
+++ b/config_sample.py
@@ -183,7 +183,14 @@ LEECH_CAPTION = ""
 THUMBNAIL_LAYOUT = ""
 
 # Log Channels
-LEECH_DUMP_CHAT = ""
+LEECH_LOG_CHAT = ""
+# Named leech dump chats, selectable per task with the -ud flag.
+# The chosen chat becomes the primary upload destination for the task.
+# Format: {"name": chat_id}
+LEECH_DUMP_CHATS = {
+    # "A": -1001234567890,
+    # "B": -1009876543210,
+}
 LINKS_LOG_ID = ""
 MIRROR_LOG_ID = ""
 

--- a/config_sample.py
+++ b/config_sample.py
@@ -179,6 +179,13 @@ THUMBNAIL_LAYOUT = ""
 
 # Log Channels
 LEECH_DUMP_CHAT = ""
+# Named leech dump chats, selectable per task with the -du flag.
+# The chosen chat becomes the primary upload destination for the task.
+# Format: {"name": chat_id}
+LEECH_DUMP_CHATS = {
+    # "A": -1001234567890,
+    # "B": -1009876543210,
+}
 LINKS_LOG_ID = ""
 MIRROR_LOG_ID = ""
 


### PR DESCRIPTION
Adds LEECH_DUMP_CHATS, a named dict config mapping dump chat names to chat IDs, plus a -du flag on mirror/leech and yt-dlp commands to choose which dump chat a task's primary/direct upload targets. -du also accepts a raw chat ID or @username so the flag works without any config.

- mirror_leech.py / ytdlp.py: parse -du into listener.dump_dest
- common.py: resolve dump_dest against Config.LEECH_DUMP_CHATS and override up_dest (the single destination used by hyper/direct send)
- telegram_download.py: tg->tg hyper download dump follows the resolved up_dest instead of only the global LEECH_DUMP_CHAT
- bot_settings.py: admin /var support for LEECH_DUMP_CHATS (dict)
- config_sample.py: document the new config

Behavior is unchanged when -du is omitted.

## Summary by Sourcery

Add per-task dump-chat selection for mirror, leech, and yt-dlp workflows while preserving existing defaults and legacy configuration compatibility.

New Features:
- Allow mirror, leech, and yt-dlp tasks to select a per-task dump chat using the -ud flag, including configured names, raw chat IDs, and usernames.
- Provide interactive dump-chat selection when an unrecognized configured name is supplied.
- Support managing named dump-chat mappings through administrator settings.

Bug Fixes:
- Preserve compatibility with the legacy LEECH_DUMP_CHAT configuration while separating leech logging from task dump destinations.

Enhancements:
- Route task uploads and Telegram hyper-downloads through the selected dump destination while retaining the existing default behavior when no destination is specified.

Documentation:
- Document the separate leech log chat and named dump-chat configuration in the sample configuration and administrator settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive destination-chat selection for leech downloads, including confirmation and cancellation.
  * Mirror and media download commands now accept the `-ud` option.
  * Added configurable named destinations supporting chat IDs and usernames.
  * Added stream-related settings and direct stream/download links where available.
* **Bug Fixes**
  * Improved destination validation and automatic migration from legacy settings.
  * Invalid destination configurations are rejected without being saved.
  * Improved AllDebrid cleanup after download errors.
* **Documentation**
  * Updated sample configuration and guidance for `LEECH_LOG_CHAT`, named destinations, and `-ud`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->