### PR TITLE
Fix authorize and unauthorize: handle topic messages correctly and revoke AUTH when all thread_ids are removed

### DIFF
--- a/bot/modules/chat_permission.py
+++ b/bot/modules/chat_permission.py
@@ -53,7 +53,10 @@ async def authorize(_, message):
             chat_id, thread_id = list(map(int, msg[1].split("|")))
         else:
             chat_id = int(msg[1].strip())
-    elif reply_to := message.reply_to_message:
+    elif (reply_to := message.reply_to_message) and (not reply_to.text and not reply_to.caption):
+            chat_id = message.chat.id
+            thread_id = message.message_thread_id
+    elif reply_to:
         chat_id = (reply_to.from_user or reply_to.sender_chat).id
     else:
         if message.is_topic_message:
@@ -90,17 +93,20 @@ async def unauthorize(_, message):
             chat_id, thread_id = list(map(int, msg[1].split("|")))
         else:
             chat_id = int(msg[1].strip())
-    elif reply_to := message.reply_to_message:
+    elif (reply_to := message.reply_to_message) and (not reply_to.text and not reply_to.caption):
+            chat_id = message.chat.id
+            thread_id = message.message_thread_id
+    elif reply_to:
         chat_id = (reply_to.from_user or reply_to.sender_chat).id
     else:
         if message.is_topic_message:
             thread_id = message.message_thread_id
         chat_id = message.chat.id
     if chat_id in user_data and user_data[chat_id].get("AUTH"):
-        if thread_id is not None and thread_id in user_data[chat_id].get(
-            "thread_ids", []
-        ):
+        if thread_id and thread_id in user_data[chat_id].get("thread_ids", []):
             user_data[chat_id]["thread_ids"].remove(thread_id)
+            if not user_data[chat_id].get("thread_ids"):
+                update_user_ldata(chat_id, "AUTH", False)
         else:
             update_user_ldata(chat_id, "AUTH", False)
         await database.update_user_data(chat_id)


### PR DESCRIPTION
## Summary by Sourcery

Correct topic-aware authorization targeting and ensure authorization is revoked after the final thread is unauthorised.

Bug Fixes:
- Handle authorization and unauthorization commands correctly when replying to topic messages without text or captions.
- Revoke chat authorization once all authorized thread IDs have been removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Replies to messages without text or captions can now be used as authorization targets for the current chat thread.

* **Bug Fixes**
  * Improved unauthorization handling for threaded chats.
  * Empty or invalid thread identifiers are no longer removed.
  * Chat authorization remains enabled while other authorized threads still exist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->