### PR TITLE
fix(gofile): handle single-file (non-folder) gofile ids

### DIFF
--- a/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
+++ b/bot/helper/mirror_leech_utils/download_utils/direct_link_generator.py
@@ -1683,6 +1683,22 @@ def gofile(url):
     except Exception as e:
         raise DirectDownloadLinkException(f"ERROR: {e.__class__.__name__}")
 
+    def __add_content_item(node, folderPath, details):
+        if not folderPath:
+            folderPath = details["title"]
+        item = {
+            "path": ospath.join(folderPath),
+            "filename": node["name"],
+            "url": node["link"],
+        }
+        if "size" in node:
+            size = node["size"]
+            if isinstance(size, str) and size.isdigit():
+                size = float(size)
+            details["total_size"] += size
+        details["contents"].append(item)
+        return folderPath
+
     def __get_token(session):
         headers = {
             "User-Agent": user_agent,
@@ -1737,30 +1753,19 @@ def gofile(url):
         if not details["title"]:
             details["title"] = data["name"] if data["type"] == "folder" else _id
 
-        contents = data["children"]
-        for content in contents.values():
+        if "children" not in data:
+            __add_content_item(data, folderPath, details)
+            return
+
+        for content in data["children"].values():
             if content["type"] == "folder":
                 if not content["public"]:
                     continue
-                if not folderPath:
-                    newFolderPath = ospath.join(details["title"], content["name"])
-                else:
-                    newFolderPath = ospath.join(folderPath, content["name"])
+                base = folderPath if folderPath else details["title"]
+                newFolderPath = ospath.join(base, content["name"])
                 __fetch_links(session, content["id"], newFolderPath)
             else:
-                if not folderPath:
-                    folderPath = details["title"]
-                item = {
-                    "path": ospath.join(folderPath),
-                    "filename": content["name"],
-                    "url": content["link"],
-                }
-                if "size" in content:
-                    size = content["size"]
-                    if isinstance(size, str) and size.isdigit():
-                        size = float(size)
-                    details["total_size"] += size
-                details["contents"].append(item)
+                folderPath = __add_content_item(content, folderPath, details)
 
     details = {"contents": [], "title": "", "total_size": 0}
     with Session() as session:


### PR DESCRIPTION
## Summary
`gofile()` assumed every fetched node had a `children` key (i.e. was a folder). Direct links to a single file (no folder) would throw, since `data["children"]` didn't exist on file nodes.

## Changes
- Extracted the per-file item-building logic (path, filename, url, size accumulation) into a new `__add_content_item` helper, shared by both the folder and single-file paths.
- `__fetch_links` now checks for `"children" not in data` up front — if the node is a single file, it adds the item directly and returns instead of trying to iterate children.
- Simplified folder path construction (`newFolderPath`) using a `base` variable instead of duplicating the `if not folderPath` branch for both folder and file cases.

## Testing
- Verified folder gofile links still resolve and populate `contents`/`total_size` as before.
- Verified a single-file gofile id (no `children` in response) now resolves correctly instead of erroring.

## Summary by Sourcery

Handle both single-file and folder GoFile nodes when generating direct download links.

Bug Fixes:
- Support resolving direct GoFile links that reference a single file instead of a folder.

Enhancements:
- Consolidate GoFile item creation and simplify folder path handling while preserving folder link behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gofile link handling when responses contain a single content item without a folder listing.
  * Enhanced processing of nested folders and files to ensure content links are discovered consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->