### PR TITLE
Tune qbittorrent defaults and fix aria2 tracker fetching

### DIFF
--- a/configs/qbittorrent/qBittorrent/config/qBittorrent.conf
+++ b/configs/qbittorrent/qBittorrent/config/qBittorrent.conf
@@ -1,24 +1,20 @@
 [Application]
-MemoryWorkingSetLimit=2048
+MemoryWorkingSetLimit=512
 
 [BitTorrent]
 Session\AddExtensionToIncompleteFiles=false
 Session\AddTrackersEnabled=false
 Session\AnnounceToAllTrackers=true
 Session\AnonymousModeEnabled=false
-Session\AsyncIOThreadsCount=32
+Session\AsyncIOThreadsCount=16
 Session\ConnectionSpeed=-1
 Session\DHTEnabled=true
-Session\DiskCacheSize=1024
-Session\DiskIOReadMode=1
-Session\DiskIOType=1
-Session\DiskIOWriteMode=1
-Session\FilePoolSize=5000
+Session\DiskCacheSize=-1
 Session\GlobalDLSpeedLimit=0
 Session\GlobalMaxRatio=-1
 Session\GlobalMaxSeedingMinutes=-1
 Session\GlobalUPSpeedLimit=0
-Session\HashingThreadsCount=4
+Session\HashingThreadsCount=1
 Session\IgnoreSlowTorrentsForQueueing=true
 Session\IncludeOverheadInLimits=false
 Session\LSDEnabled=true
@@ -26,7 +22,6 @@ Session\MaxActiveCheckingTorrents=3
 Session\MaxActiveDownloads=1000
 Session\MaxActiveTorrents=1000
 Session\MaxActiveUploads=1000
-Session\MaxConcurrentHTTPAnnounces=100
 Session\MaxConnections=-1
 Session\MaxConnectionsPerTorrent=-1
 Session\MaxRatioAction=0
@@ -34,15 +29,13 @@ Session\MaxUploads=-1
 Session\MaxUploadsPerTorrent=-1
 Session\MultiConnectionsPerIp=true
 Session\PexEnabled=true
+Session\PerformanceWarning=true
 Session\Preallocation=true
 Session\QueueingSystemEnabled=false
-Session\SendBufferWatermark=5120
-Session\SendBufferWatermarkFactor=200
 Session\SlowTorrentsDownloadRate=2
 Session\SlowTorrentsInactivityTimer=600
 Session\SlowTorrentsUploadRate=2
 Session\StopTrackerTimeout=5
-Session\UseOSCache=false
 TrackerEnabled=true
 
 [LegalNotice]

--- a/setpkgs.sh
+++ b/setpkgs.sh
@@ -18,52 +18,61 @@ else
     SAB_CMD="cpulimit -l $CPU_LIMIT -- $SABNZBDPLUS"
 fi
 
-tracker_list=$(curl -Ns https://cdn.jsdelivr.net/gh/ngosang/trackerslist@master/trackers_all.txt | awk '$0' | tr '\n\n' ',')
 $ARIA2_CMD \
-    --daemon=true \
-    --rpc-listen-all=true \
-    --enable-rpc=true \
-    --rpc-max-request-size=1024M \
-    --max-concurrent-downloads=1000 \
-    --max-connection-per-server=16 \
-    --split=16 \
-    --min-split-size=32M \
-    --optimize-concurrent-downloads=true \
-    --continue=true \
-    --auto-file-renaming=true \
     --allow-overwrite=true \
-    --force-save=false \
-    --content-disposition-default-utf8=true \
-    --user-agent="Wget/1.12" \
-    --http-accept-gzip=true \
-    --max-tries=20 \
-    --max-file-not-found=0 \
-    --check-certificate=false \
+    --auto-file-renaming=true \
     --bt-enable-lpd=true \
     --bt-detach-seed-only=true \
     --bt-remove-unselected-file=true \
+    --bt-tracker="" \
     --bt-max-peers=0 \
-    --bt-max-open-files=1000 \
-    --bt-request-peer-speed-limit=1M \
+    --enable-rpc=true \
+    --rpc-listen-all=true \
+    --rpc-max-request-size=1024M \
+    --max-connection-per-server=10 \
+    --max-concurrent-downloads=1000 \
+    --split=10 \
     --seed-ratio=0 \
-    --peer-id-prefix="-qB5220-" \
-    --peer-agent="qBittorrent/5.2.2" \
-    --follow-torrent=mem \
-    --reuse-uri=true \
-    --socket-recv-buffer-size=16M \
-    --disable-ipv6=false \
-    --connect-timeout=30 \
-    --timeout=30 \
-    --retry-wait=5 \
-    --file-allocation=falloc \
-    --disk-cache=64M \
     --check-integrity=true \
-    --max-upload-limit=1K \
+    --continue=true \
+    --daemon=true \
+    --disk-cache=40M \
+    --force-save=true \
+    --min-split-size=10M \
+    --follow-torrent=mem \
+    --check-certificate=false \
+    --optimize-concurrent-downloads=true \
+    --http-accept-gzip=true \
+    --max-file-not-found=0 \
+    --max-tries=20 \
+    --peer-id-prefix="-qB4520-" \
+    --reuse-uri=true \
+    --content-disposition-default-utf8=true \
+    --user-agent="Wget/1.12" \
+    --peer-agent="qBittorrent/4.5.2" \
     --quiet=true \
     --summary-interval=0 \
-    --save-session= \
-    --save-session-interval=0 \
-    --bt-tracker="[$tracker_list]"
+    --max-upload-limit=1K \
+    --connect-timeout=30 \
+    --timeout=30 \
+    --retry-wait=5
+
+(
+    trackers=$(curl -Ns --connect-timeout 5 --max-time 30 \
+        https://cdn.jsdelivr.net/gh/ngosang/trackerslist@master/trackers_all.txt 2>/dev/null \
+        | awk '$0' | tr '\n' ',')
+    if [ -n "$trackers" ]; then
+        for _ in $(seq 1 20); do
+            if curl -s --connect-timeout 2 --max-time 3 -o /dev/null \
+                http://127.0.0.1:6800/jsonrpc 2>/dev/null; then
+                break
+            fi
+            sleep 1
+        done
+        payload="{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"aria2.changeGlobalOption\",\"params\":[{\"bt-tracker\":\"[${trackers%,}]\"}]}"
+        curl -s -X POST -d "$payload" http://127.0.0.1:6800/jsonrpc >/dev/null 2>&1
+    fi
+) &
 
 if [ -n "$SABNZBDPLUS" ]; then
     $SAB_CMD -f configs/sabnzbd/SABnzbd.ini -s :::8070 -b 0 -d -c -l 0 --console


### PR DESCRIPTION
## Summary by Sourcery

Tune torrent client defaults and reliably configure aria2 with the fetched tracker list.

Bug Fixes:
- Fix aria2 tracker configuration so the tracker list is fetched and applied through the RPC interface after startup, with connection and request timeouts.

Enhancements:
- Tune qBittorrent resource usage and performance defaults for lower memory consumption and reduced concurrency.
- Align aria2 download, caching, peer, and persistence settings with the updated client defaults.